### PR TITLE
update flake to use `packages.default`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,49 +11,50 @@
         overlays = [ (import rust-overlay) ];
         pkgs = (import nixpkgs) { inherit system overlays; };
         naersk' = pkgs.callPackage naersk { };
+      in {
+        packages = rec {
+          waytrogen = naersk'.buildPackage {
+            src = ./.;
+            nativeBuildInputs = with pkgs; [
+              pkg-config
+              glib
+              wrapGAppsHook4
+              sqlite
+              bash
+            ];
+            buildInputs = with pkgs; [
+              glib
+              gtk4
+              ffmpeg
+              sqlite
+              openssl
+              gsettings-desktop-schemas
+            ];
 
-      in rec {
-        defaultPackage = naersk'.buildPackage {
-          src = ./.;
-          nativeBuildInputs = with pkgs; [
-            pkg-config
-            glib
-            wrapGAppsHook4
-            sqlite
-            bash
-          ];
-          buildInputs = with pkgs; [
-            glib
-            gtk4
-            ffmpeg
-            sqlite
-            openssl
-            gsettings-desktop-schemas
-          ];
+            env = { OPENSSL_NO_VENDOR = 1; };
 
+            postInstall = ''
+              install -Dm644 org.Waytrogen.Waytrogen.gschema.xml -t $out/share/gsettings-schemas/$name/glib-2.0/schemas
+              glib-compile-schemas $out/share/gsettings-schemas/$name/glib-2.0/schemas
+              install -Dm644 waytrogen.desktop $out/share/applications/waytrogen.desktop
+              install -Dm644 README-Assets/WaytrogenLogo.svg $out/share/icons/hicolor/scalable/apps/waytrogen.svg
+              while IFS= read -r lang; do
+                    mkdir -p $out/share/locale/$lang/LC_MESSAGES
+                    msgfmt locales/$lang/LC_MESSAGES/waytrogen.po -o $out/share/locale/$lang/LC_MESSAGES/waytrogen.mo
+              done < locales/LINGUAS
+            '';
 
-          env = { OPENSSL_NO_VENDOR = 1; };
-
-          postInstall = ''
-          install -Dm644 org.Waytrogen.Waytrogen.gschema.xml -t $out/share/gsettings-schemas/$name/glib-2.0/schemas
-          glib-compile-schemas $out/share/gsettings-schemas/$name/glib-2.0/schemas
-          install -Dm644 waytrogen.desktop $out/share/applications/waytrogen.desktop
-          install -Dm644 README-Assets/WaytrogenLogo.svg $out/share/icons/hicolor/scalable/apps/waytrogen.svg
-          while IFS= read -r lang; do
-                mkdir -p $out/share/locale/$lang/LC_MESSAGES
-                msgfmt locales/$lang/LC_MESSAGES/waytrogen.po -o $out/share/locale/$lang/LC_MESSAGES/waytrogen.mo
-          done < locales/LINGUAS
-          '';
-
-          meta = {
-            description = "A lightning fast wallpaper setter for Wayland.";
-            longDescription =
-              "A GUI wallpaper setter for Wayland that is a spiritual successor for the minimalistic wallpaper changer for X11 nitrogen. Written purely in the Rust 🦀 programming language. Supports hyprpaper, swaybg, mpvpaper and swww wallpaper changers.";
-            homepage = "https://github.com/nikolaizombie1/waytrogen";
+            meta = {
+              description = "A lightning fast wallpaper setter for Wayland.";
+              longDescription =
+                "A GUI wallpaper setter for Wayland that is a spiritual successor for the minimalistic wallpaper changer for X11 nitrogen. Written purely in the Rust 🦀 programming language. Supports hyprpaper, swaybg, mpvpaper and swww wallpaper changers.";
+              homepage = "https://github.com/nikolaizombie1/waytrogen";
+            };
           };
+          default = waytrogen;
         };
 
-        devShell = pkgs.mkShell {
+        devShells.default = pkgs.mkShell {
           nativeBuildInputs = with pkgs; [
             glibcLocales
             pkg-config


### PR DESCRIPTION
In [Nix 2.7](https://nix.dev/manual/nix/2.24/release-notes/rl-2.7.html?highlight=defaultPackage.%3Csystem%3E%20%20packages.%3Csystem%3E.default%20devShell.%3Csystem%3E%20devShells.%3Csystem%3E.default#release-27-2022-03-07) `defaultPackage` has been replaced by `packages.default` same for `devShell`, which has been replaced with `devShells.default`. I also formatted the flake. If you have issues with my formatting feel free to change it.