### PR TITLE
Fix short flag conflict for `hide_bottom_bar` with clap's help flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -339,7 +339,7 @@ pub struct Cli {
     #[arg(short, long)]
     /// Delete image cache.
     pub delete_cache: bool,
-    #[arg(short, long)]
+    #[arg(short = 'b', long)]
     /// Hide bottom bar
     pub hide_bottom_bar: Option<bool>,
 }


### PR DESCRIPTION
This fixes a panic caused by a short flag conflict in the CLI.

Previously, `hide_bottom_bar` used `#[arg(short, long)]`, which implicitly assigns `-h` as the short flag. This conflicts with clap's auto-generated `-h/--help` flag and causes a runtime panic:

"Short option names must be unique for each argument, but '-h' is in use by both 'hide_bottom_bar' and 'help'"

### Changes
- Explicitly set a non-conflicting short flag:
  - `hide_bottom_bar`: `-b` / `--hide-bottom-bar`

### Result
- Eliminates the panic
- Preserves clap’s default help behavior

### Notes
- This is a minimal, non-breaking fix
- No changes to existing long flag usage