### PR TITLE
feat: make image filter reactive to text changes

### DIFF
--- a/src/main_window.rs
+++ b/src/main_window.rs
@@ -938,7 +938,7 @@ fn create_image_filter_entry(
     settings
         .bind("image-filter", &entry.buffer(), "text")
         .build();
-    entry.connect_activate(clone!(
+    entry.connect_changed(clone!(
         #[strong]
         image_list_store,
         #[strong]


### PR DESCRIPTION
Change connect_activate to connect_changed for the image filter entry, so the list updates immediately as user types instead of requiring Enter key press.

## Summary
- Changed image filter entry from `connect_activate` to `connect_changed`
- The "Find Image" field now filters images in real-time as the user types
- Previously required pressing Enter to trigger the filter