### PR TITLE
Keep gSlapper running between wallpaper changes

### DIFF
--- a/locales/en.ftl
+++ b/locales/en.ftl
@@ -305,6 +305,41 @@ gslapper-pause-mode-tooltip = Playback control when wallpaper is hidden.
 
 gslapper-scale-mode-tooltip = Scaling method for the video.
 
+gslapper-settings = gSlapper settings
+gslapper-settings-tooltip = Configure gSlapper for the selected output.
+gslapper-settings-description = Launch settings restart gSlapper for this output. Playback and cache actions apply now.
+gslapper-output = Output
+gslapper-status = Status
+gslapper-not-running = No Waytrogen-managed gSlapper process is running for this output.
+gslapper-playing = Playing
+gslapper-paused = Paused
+gslapper-pause = Pause
+gslapper-resume = Resume
+gslapper-wallpaper-behavior = Wallpaper behavior
+gslapper-scale-mode = Scale mode
+gslapper-loop-video = Loop video
+gslapper-hidden-playback = When hidden
+gslapper-transitions = Transitions
+gslapper-enable-transition = Fade between wallpapers
+gslapper-transition-duration = Duration in seconds
+gslapper-show-advanced = Show advanced settings
+gslapper-hide-advanced = Hide advanced settings
+gslapper-fps-cap = FPS cap
+gslapper-cache-size = Cache size (MB)
+gslapper-cache-status = Cache
+gslapper-cache-unavailable = Not running
+gslapper-cache-refresh = Refresh
+gslapper-cache-clear-unused = Clear unused
+gslapper-cache-clear-all = Clear all
+gslapper-raw-options = GStreamer options
+gslapper-raw-options-help = Passed to gSlapper unchanged. Invalid options can prevent startup.
+gslapper-cancel = Cancel
+gslapper-save = Save
+gslapper-fps-description = Maximum playback frame rate. Supported values: 30, 60, or 100.
+gslapper-transition-description = Fade between wallpaper changes.
+gslapper-transition-duration-description = Fade duration in seconds, from 0.1 to 5.
+gslapper-cache-size-description = Maximum gSlapper cache size in MB.
+
 hyprpaper-fit-mode-tooltip = Determines how to display the image.
 
 image-folder-tooltip = Root wallpaper folder.

--- a/locales/es.ftl
+++ b/locales/es.ftl
@@ -306,6 +306,41 @@ gslapper-pause-mode-tooltip = Opción de reproducción cuando el video esta ocul
 
 gslapper-scale-mode-tooltip = Método de escalamiento para el video.
 
+gslapper-settings = Ajustes de gSlapper
+gslapper-settings-tooltip = Configura gSlapper para la salida seleccionada.
+gslapper-settings-description = Los ajustes de inicio reinician gSlapper para esta salida. Los controles de reproducción y caché se aplican ahora.
+gslapper-output = Salida
+gslapper-status = Estado
+gslapper-not-running = No hay un proceso de gSlapper administrado por Waytrogen para esta salida.
+gslapper-playing = Reproduciendo
+gslapper-paused = En pausa
+gslapper-pause = Pausar
+gslapper-resume = Reanudar
+gslapper-wallpaper-behavior = Comportamiento del fondo
+gslapper-scale-mode = Modo de escala
+gslapper-loop-video = Repetir video
+gslapper-hidden-playback = Al ocultarse
+gslapper-transitions = Transiciones
+gslapper-enable-transition = Fundido entre fondos
+gslapper-transition-duration = Duración en segundos
+gslapper-show-advanced = Mostrar ajustes avanzados
+gslapper-hide-advanced = Ocultar ajustes avanzados
+gslapper-fps-cap = Límite de FPS
+gslapper-cache-size = Tamaño de caché (MB)
+gslapper-cache-status = Caché
+gslapper-cache-unavailable = No está en ejecución
+gslapper-cache-refresh = Actualizar
+gslapper-cache-clear-unused = Borrar sin usar
+gslapper-cache-clear-all = Borrar todo
+gslapper-raw-options = Opciones de GStreamer
+gslapper-raw-options-help = Se pasan a gSlapper sin cambios. Las opciones no válidas pueden impedir el inicio.
+gslapper-cancel = Cancelar
+gslapper-save = Guardar
+gslapper-fps-description = Frecuencia máxima de reproducción. Valores admitidos: 30, 60 o 100.
+gslapper-transition-description = Fundido entre cambios de fondo.
+gslapper-transition-duration-description = Duración del fundido en segundos, de 0,1 a 5.
+gslapper-cache-size-description = Tamaño máximo de caché de gSlapper en MB.
+
 hyprpaper-fit-mode-tooltip = Determina como la imagen esta desplegada.
 
 image-folder-tooltip = Carpeta superior de imágenes de fondo.

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1,6 +1,10 @@
 use crate::common::create_tooltip;
 use crate::locale::TRANSLATION;
 use crate::{
+    changers::gslapper::{
+        GSlapperControl, GSlapperRuntime, GSlapperStatus, apply_gslapper_settings,
+        control_gslapper, generate_gslapper_settings_dialog, load_gslapper_runtime,
+    },
     common::{
         BUTTON_HEIGHT, BUTTON_WIDTH, CacheImageFile, DEFAULT_MARGIN, Wallpaper,
         get_config_file_path, parse_executable_script,
@@ -28,7 +32,7 @@ use iced::{
     Subscription, Task,
     application::BootFn,
     event,
-    widget::{button, column, image, lazy, pick_list, row, text, text_input, toggler},
+    widget::{button, column, image, lazy, pick_list, row, stack, text, text_input, toggler},
     window,
 };
 use iced_aw::{
@@ -149,6 +153,14 @@ pub struct AppState {
     pub gslapper_loop: bool,
     gslapper_additional_options_doc: String,
     pub gslapper_additional_options: String,
+    gslapper_fps_cap_doc: String,
+    pub gslapper_fps_cap: u16,
+    gslapper_transition_enabled_doc: String,
+    pub gslapper_transition_enabled: bool,
+    gslapper_transition_duration_doc: String,
+    pub gslapper_transition_duration: f64,
+    gslapper_cache_size_doc: String,
+    pub gslapper_cache_size: u32,
     hide_changer_options_box_doc: String,
     pub hide_changer_options_box: bool,
     theme_doc: String,
@@ -176,6 +188,18 @@ pub struct AppState {
     pub internal_theme: Option<iced::Theme>,
     #[serde(skip)]
     pub image_grid_loading: bool,
+    #[serde(skip)]
+    pub gslapper_error: Option<String>,
+    #[serde(skip)]
+    pub show_gslapper_settings: bool,
+    #[serde(skip)]
+    pub show_gslapper_advanced: bool,
+    #[serde(skip)]
+    pub gslapper_settings_draft: Option<GSllaperSettings>,
+    #[serde(skip)]
+    pub gslapper_status: Option<GSlapperStatus>,
+    #[serde(skip)]
+    pub gslapper_cache_status: Option<String>,
     #[serde(skip)]
     row_offset: usize,
 }
@@ -272,6 +296,16 @@ impl Default for AppState {
             gslapper_additional_options_doc: TRANSLATION
                 .get_translation("gslapper-additional-options-desciption"),
             gslapper_additional_options: String::default(),
+            gslapper_fps_cap_doc: TRANSLATION.get_translation("gslapper-fps-description"),
+            gslapper_fps_cap: 30,
+            gslapper_transition_enabled_doc: TRANSLATION
+                .get_translation("gslapper-transition-description"),
+            gslapper_transition_enabled: false,
+            gslapper_transition_duration_doc: TRANSLATION
+                .get_translation("gslapper-transition-duration-description"),
+            gslapper_transition_duration: 0.5,
+            gslapper_cache_size_doc: TRANSLATION.get_translation("gslapper-cache-size-description"),
+            gslapper_cache_size: 256,
             hide_changer_options_box_doc: TRANSLATION.get_translation("hide-bottom-bar"),
             hide_changer_options_box: false,
             image_grid_images: Vec::default(),
@@ -290,6 +324,12 @@ impl Default for AppState {
                 .get_translation("favorite-image-only-description"),
             favorite_images_only: false,
             image_grid_loading: false,
+            gslapper_error: None,
+            show_gslapper_settings: false,
+            show_gslapper_advanced: false,
+            gslapper_settings_draft: None,
+            gslapper_status: None,
+            gslapper_cache_status: None,
             row_offset: usize::default(),
         }
     }
@@ -300,7 +340,7 @@ pub enum Messages {
     PopulateImageGrid,
     ImageGridPopulated(AppStateImages),
     ChangeWallpaper(PathBuf),
-    WallpaperChanged(PathBuf),
+    WallpaperChangeFinished(PathBuf, Result<(), String>),
     ChangeWallpaperFolder,
     PopulateMonitorDropdown,
     MonitorDropdownPopulated(Vec<String>),
@@ -347,6 +387,18 @@ pub enum Messages {
     GSlapperPauseModeChanged(GSllapperPauseMode),
     GSllaperLoopVideoChanged(bool),
     GSllaperAdditionalOptionsChanged(String),
+    GSlapperFpsChanged(u16),
+    GSlapperTransitionEnabledChanged(bool),
+    GSlapperTransitionDurationChanged(f64),
+    GSlapperCacheSizeChanged(u32),
+    OpenGSlapperSettings,
+    CloseGSlapperSettings,
+    ToggleGSlapperAdvanced,
+    SaveGSlapperSettings,
+    GSlapperRuntimeLoaded(Result<GSlapperRuntime, String>),
+    GSlapperSettingsApplied(GSllaperSettings, Result<GSlapperRuntime, String>),
+    GSlapperControlRequested(GSlapperControl),
+    GSlapperDialogPressed,
     ThemeChanged(iced::Theme),
     WallpaperFavoriteToggle(PathBuf),
     ShowFavoritesToggled(bool),
@@ -461,6 +513,10 @@ impl BootFn<AppState, Messages> for AppState {
                     pause_mode: instance.clone().gslapper_pause_mode.unwrap_or_default(),
                     loop_video: instance.clone().gslapper_loop,
                     additional_options: instance.clone().gslapper_additional_options,
+                    fps_cap: instance.gslapper_fps_cap,
+                    transition_enabled: instance.gslapper_transition_enabled,
+                    transition_duration: instance.gslapper_transition_duration,
+                    cache_size_mb: instance.gslapper_cache_size,
                 }),
             };
             Some(c)
@@ -711,10 +767,28 @@ impl AppState {
             return Task::none();
         };
         Task::future(async move {
-            changer.change(path.clone(), monitor);
-            path
+            let result = changer
+                .change(path.clone(), monitor)
+                .map_err(|error| error.to_string());
+            (path, result)
         })
-        .then(|p| Task::done(Messages::WallpaperChanged(p)))
+        .then(|(path, result)| Task::done(Messages::WallpaperChangeFinished(path, result)))
+    }
+
+    fn load_gslapper_runtime(&self) -> Task<Messages> {
+        let Some(monitor) = self.monitor.clone() else {
+            return Task::none();
+        };
+        Task::future(async move { load_gslapper_runtime(&monitor).map_err(|e| e.to_string()) })
+            .then(|result| Task::done(Messages::GSlapperRuntimeLoaded(result)))
+    }
+
+    fn control_gslapper(&self, control: GSlapperControl) -> Task<Messages> {
+        let Some(monitor) = self.monitor.clone() else {
+            return Task::none();
+        };
+        Task::future(async move { control_gslapper(&monitor, control).map_err(|e| e.to_string()) })
+            .then(|result| Task::done(Messages::GSlapperRuntimeLoaded(result)))
     }
 
     fn execute_external_script(&self, wallpaper_path: &Path) -> Task<Messages> {
@@ -854,7 +928,12 @@ impl AppState {
             | Messages::ExternalScriptExecuted
             | Messages::AwwwAdvancedSettingsButtonClicked
             | Messages::PopulateMonitorDropdown => Task::none(),
-            Messages::WallpaperChanged(wallpaper_path) => {
+            Messages::WallpaperChangeFinished(_, Err(error)) => {
+                self.gslapper_error = Some(error);
+                Task::none()
+            }
+            Messages::WallpaperChangeFinished(wallpaper_path, Ok(())) => {
+                self.gslapper_error = None;
                 if let Some(changer) = &self.changer
                     && let Some(monitor) = &self.monitor
                 {
@@ -1280,52 +1359,132 @@ impl AppState {
                 }
                 Task::none()
             }
+            Messages::OpenGSlapperSettings => {
+                if let Some(WallpaperChangers::GSlapper(settings)) = &self.changer {
+                    self.gslapper_settings_draft = Some(settings.clone());
+                    self.show_gslapper_settings = true;
+                    self.gslapper_error = None;
+                    return self.load_gslapper_runtime();
+                }
+                Task::none()
+            }
+            Messages::CloseGSlapperSettings => {
+                self.show_gslapper_settings = false;
+                self.gslapper_settings_draft = None;
+                Task::none()
+            }
+            Messages::ToggleGSlapperAdvanced => {
+                self.show_gslapper_advanced = !self.show_gslapper_advanced;
+                Task::none()
+            }
+            Messages::GSlapperRuntimeLoaded(Ok(runtime)) => {
+                self.gslapper_status = runtime.status;
+                self.gslapper_cache_status = runtime.cache_status;
+                self.gslapper_error = None;
+                Task::none()
+            }
+            Messages::GSlapperRuntimeLoaded(Err(error)) => {
+                self.gslapper_status = None;
+                self.gslapper_cache_status = None;
+                self.gslapper_error = Some(error);
+                Task::none()
+            }
+            Messages::GSlapperControlRequested(control) => self.control_gslapper(control),
+            Messages::GSlapperDialogPressed => Task::none(),
+            Messages::GSlapperSettingsApplied(settings, Ok(runtime)) => {
+                self.gslapper_scale_mode = Some(settings.scale_mode.clone());
+                self.gslapper_pause_mode = Some(settings.pause_mode.clone());
+                self.gslapper_loop = settings.loop_video;
+                self.gslapper_additional_options
+                    .clone_from(&settings.additional_options);
+                self.gslapper_fps_cap = settings.fps_cap;
+                self.gslapper_transition_enabled = settings.transition_enabled;
+                self.gslapper_transition_duration = settings.transition_duration;
+                self.gslapper_cache_size = settings.cache_size_mb;
+                self.changer = Some(WallpaperChangers::GSlapper(settings));
+                self.gslapper_status = runtime.status;
+                self.gslapper_cache_status = runtime.cache_status;
+                self.gslapper_error = None;
+                Task::none()
+            }
+            Messages::GSlapperSettingsApplied(_, Err(error)) => {
+                self.gslapper_status = None;
+                self.gslapper_cache_status = None;
+                self.gslapper_error = Some(error);
+                Task::none()
+            }
+            Messages::SaveGSlapperSettings => {
+                let Some(settings) = self.gslapper_settings_draft.clone() else {
+                    return Task::none();
+                };
+                if let Err(error) = settings.validate() {
+                    self.gslapper_error = Some(error);
+                    return Task::none();
+                }
+                let current = match &self.changer {
+                    Some(WallpaperChangers::GSlapper(current)) => current.clone(),
+                    _ => return Task::none(),
+                };
+                let Some(monitor) = self.monitor.clone() else {
+                    return Task::none();
+                };
+                let applied_settings = settings.clone();
+                Task::future(async move {
+                    apply_gslapper_settings(&current, &settings, &monitor)
+                        .map_err(|e| e.to_string())
+                })
+                .then(move |result| {
+                    Task::done(Messages::GSlapperSettingsApplied(
+                        applied_settings.clone(),
+                        result,
+                    ))
+                })
+            }
             Messages::GSllaperScaleModeChanged(gsllapper_scale_mode) => {
-                self.gslapper_scale_mode = Some(gsllapper_scale_mode.clone());
-                if let Some(changer) = &self.changer
-                    && let WallpaperChangers::GSlapper(settings) = changer
-                {
-                    self.changer = Some(WallpaperChangers::GSlapper(GSllaperSettings {
-                        scale_mode: gsllapper_scale_mode,
-                        ..settings.clone()
-                    }));
+                if let Some(settings) = &mut self.gslapper_settings_draft {
+                    settings.scale_mode = gsllapper_scale_mode;
                 }
                 Task::none()
             }
             Messages::GSlapperPauseModeChanged(gsllapper_pause_mode) => {
-                self.gslapper_pause_mode = Some(gsllapper_pause_mode.clone());
-                if let Some(changer) = &self.changer
-                    && let WallpaperChangers::GSlapper(settings) = changer
-                {
-                    self.changer = Some(WallpaperChangers::GSlapper(GSllaperSettings {
-                        pause_mode: gsllapper_pause_mode,
-                        ..settings.clone()
-                    }));
+                if let Some(settings) = &mut self.gslapper_settings_draft {
+                    settings.pause_mode = gsllapper_pause_mode;
                 }
                 Task::none()
             }
             Messages::GSllaperLoopVideoChanged(b) => {
-                self.gslapper_loop = b;
-                if let Some(changer) = &self.changer
-                    && let WallpaperChangers::GSlapper(settings) = changer
-                {
-                    self.changer = Some(WallpaperChangers::GSlapper(GSllaperSettings {
-                        loop_video: b,
-                        ..settings.clone()
-                    }));
+                if let Some(settings) = &mut self.gslapper_settings_draft {
+                    settings.loop_video = b;
                 }
                 Task::none()
             }
             Messages::GSllaperAdditionalOptionsChanged(additional_options) => {
-                self.gslapper_additional_options
-                    .clone_from(&additional_options);
-                if let Some(changer) = &self.changer
-                    && let WallpaperChangers::GSlapper(settings) = changer
-                {
-                    self.changer = Some(WallpaperChangers::GSlapper(GSllaperSettings {
-                        additional_options,
-                        ..settings.clone()
-                    }));
+                if let Some(settings) = &mut self.gslapper_settings_draft {
+                    settings.additional_options = additional_options;
+                }
+                Task::none()
+            }
+            Messages::GSlapperFpsChanged(fps) => {
+                if let Some(settings) = &mut self.gslapper_settings_draft {
+                    settings.fps_cap = fps;
+                }
+                Task::none()
+            }
+            Messages::GSlapperTransitionEnabledChanged(enabled) => {
+                if let Some(settings) = &mut self.gslapper_settings_draft {
+                    settings.transition_enabled = enabled;
+                }
+                Task::none()
+            }
+            Messages::GSlapperTransitionDurationChanged(duration) => {
+                if let Some(settings) = &mut self.gslapper_settings_draft {
+                    settings.transition_duration = duration;
+                }
+                Task::none()
+            }
+            Messages::GSlapperCacheSizeChanged(size) => {
+                if let Some(settings) = &mut self.gslapper_settings_draft {
+                    settings.cache_size_mb = size;
                 }
                 Task::none()
             }
@@ -1375,7 +1534,7 @@ impl AppState {
     }
 
     pub fn view(&self) -> Element<'_, Messages> {
-        match &self.changer {
+        let content = match &self.changer {
             Some(changer) => {
                 let image_grid: Element<'_, Messages> = if self.image_grid_loading {
                     row![
@@ -1653,43 +1812,79 @@ impl AppState {
             .height(Fill)
             .width(Fill)
             .into(),
+        };
+
+        if self.show_gslapper_settings {
+            stack![
+                content,
+                mouse_area(
+                    container(text(""))
+                        .style(|_| {
+                            container::Style::default()
+                                .background(Color::from_rgba(0.0, 0.0, 0.0, 0.55))
+                        })
+                        .width(Fill)
+                        .height(Fill),
+                )
+                .on_press(Messages::CloseGSlapperSettings),
+                container(
+                    mouse_area(generate_gslapper_settings_dialog(self))
+                        .on_press(Messages::GSlapperDialogPressed),
+                )
+                .align_x(Center)
+                .align_y(Center)
+                .width(Fill)
+                .height(Fill),
+            ]
+            .width(Fill)
+            .height(Fill)
+            .into()
+        } else {
+            content
         }
     }
 
     fn subscription(&self) -> Subscription<Messages> {
-        Subscription::filter_map(event::listen(), |event| match event {
-            iced::Event::Window(iced::window::Event::CloseRequested) => {
-                Some(Messages::CloseRequested)
-            }
-            iced::Event::Window(iced::window::Event::Resized(s)) => {
-                IMAGE_GRID_COLUMNS.store(
-                    (s.width / (BUTTON_WIDTH + 4.0 * DEFAULT_MARGIN)).floor() as usize,
-                    std::sync::atomic::Ordering::Relaxed,
-                );
-                IMAGE_GRID_ROWS.store(
-                    (s.height / (BUTTON_HEIGHT + 4.0 * DEFAULT_MARGIN)).floor() as usize,
-                    std::sync::atomic::Ordering::Relaxed,
-                );
-                Some(Messages::ResetRowOffset)
-            }
-            iced::Event::Mouse(iced::mouse::Event::WheelScrolled { delta }) => match delta {
-                iced::mouse::ScrollDelta::Lines { x: _, y } => {
-                    if y < 0.0 {
-                        Some(Messages::ImageGridScrollUp)
-                    } else {
-                        Some(Messages::ImgaeGridScrollDown)
-                    }
+        Subscription::filter_map(
+            event::listen().with(self.show_gslapper_settings),
+            |(settings_open, event)| match event {
+                iced::Event::Window(iced::window::Event::CloseRequested) => {
+                    Some(Messages::CloseRequested)
                 }
-                iced::mouse::ScrollDelta::Pixels { x: _, y } => {
-                    if y < 0.0 {
-                        Some(Messages::ImageGridScrollUp)
-                    } else {
-                        Some(Messages::ImgaeGridScrollDown)
-                    }
+                iced::Event::Window(iced::window::Event::Resized(s)) => {
+                    IMAGE_GRID_COLUMNS.store(
+                        (s.width / (BUTTON_WIDTH + 4.0 * DEFAULT_MARGIN)).floor() as usize,
+                        std::sync::atomic::Ordering::Relaxed,
+                    );
+                    IMAGE_GRID_ROWS.store(
+                        (s.height / (BUTTON_HEIGHT + 4.0 * DEFAULT_MARGIN)).floor() as usize,
+                        std::sync::atomic::Ordering::Relaxed,
+                    );
+                    Some(Messages::ResetRowOffset)
                 }
+                iced::Event::Keyboard(iced::keyboard::Event::KeyPressed {
+                    key: iced::keyboard::Key::Named(iced::keyboard::key::Named::Escape),
+                    ..
+                }) if settings_open => Some(Messages::CloseGSlapperSettings),
+                iced::Event::Mouse(iced::mouse::Event::WheelScrolled { delta }) => match delta {
+                    iced::mouse::ScrollDelta::Lines { x: _, y } => {
+                        if y < 0.0 {
+                            Some(Messages::ImageGridScrollUp)
+                        } else {
+                            Some(Messages::ImgaeGridScrollDown)
+                        }
+                    }
+                    iced::mouse::ScrollDelta::Pixels { x: _, y } => {
+                        if y < 0.0 {
+                            Some(Messages::ImageGridScrollUp)
+                        } else {
+                            Some(Messages::ImgaeGridScrollDown)
+                        }
+                    }
+                },
+                _ => None,
             },
-            _ => None,
-        })
+        )
     }
 
     fn theme(&self) -> iced::Theme {
@@ -1707,5 +1902,91 @@ impl AppState {
             .exit_on_close_request(false)
             .theme(Self::theme)
             .run()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failed_wallpaper_change_is_not_saved() {
+        let mut app = AppState {
+            changer: Some(WallpaperChangers::GSlapper(GSllaperSettings::default())),
+            monitor: Some("DP-1".to_owned()),
+            saved_wallpapers: Vec::new(),
+            ..AppState::default()
+        };
+        let path = PathBuf::from("/tmp/missing.png");
+
+        let _ = app.update(Messages::WallpaperChangeFinished(
+            path,
+            Err("gSlapper failed".to_owned()),
+        ));
+
+        assert!(app.saved_wallpapers.is_empty());
+        assert_eq!(app.gslapper_error.as_deref(), Some("gSlapper failed"));
+    }
+
+    #[test]
+    fn opening_gslapper_settings_copies_current_settings() {
+        let settings = GSllaperSettings {
+            fps_cap: 60,
+            ..GSllaperSettings::default()
+        };
+        let mut app = AppState {
+            changer: Some(WallpaperChangers::GSlapper(settings.clone())),
+            monitor: Some("DP-1".to_owned()),
+            ..AppState::default()
+        };
+
+        let _ = app.update(Messages::OpenGSlapperSettings);
+
+        assert!(app.show_gslapper_settings);
+        assert_eq!(app.gslapper_settings_draft, Some(settings));
+    }
+
+    #[test]
+    fn failed_settings_apply_keeps_last_working_settings() {
+        let current = GSllaperSettings::default();
+        let mut requested = current.clone();
+        requested.fps_cap = 60;
+        let mut app = AppState {
+            changer: Some(WallpaperChangers::GSlapper(current.clone())),
+            gslapper_settings_draft: Some(requested.clone()),
+            ..AppState::default()
+        };
+
+        let _ = app.update(Messages::GSlapperSettingsApplied(
+            requested,
+            Err("restart failed".to_owned()),
+        ));
+
+        assert_eq!(app.changer, Some(WallpaperChangers::GSlapper(current)));
+        assert_eq!(app.gslapper_error.as_deref(), Some("restart failed"));
+    }
+
+    #[test]
+    fn old_app_state_keeps_user_settings_and_defaults_new_gslapper_fields() {
+        let app = AppState {
+            image_filter: "keep me".to_owned(),
+            ..AppState::default()
+        };
+        let mut value = serde_json::to_value(app).unwrap();
+        let object = value.as_object_mut().unwrap();
+        for field in [
+            "gslapper_fps_cap",
+            "gslapper_transition_enabled",
+            "gslapper_transition_duration",
+            "gslapper_cache_size",
+        ] {
+            object.remove(field);
+        }
+
+        let restored: AppState = serde_json::from_value(value).unwrap();
+
+        assert_eq!(restored.image_filter, "keep me");
+        assert_eq!(restored.gslapper_fps_cap, 30);
+        assert_eq!(restored.gslapper_cache_size, 256);
     }
 }

--- a/src/changers/gslapper.rs
+++ b/src/changers/gslapper.rs
@@ -2,180 +2,1110 @@ use crate::{
     app_state::{AppState, Messages},
     common::create_tooltip,
     locale::TRANSLATION,
-    wallpaper_changers::{GSllapperPauseMode, GSllapperScaleMode, WallpaperChangers},
+    wallpaper_changers::{
+        GSllaperSettings, GSllapperPauseMode, GSllapperScaleMode, WallpaperChangers,
+    },
 };
 use iced::{
-    Element,
-    widget::{pick_list, text, text_input, toggler},
+    Alignment, Element, Length,
+    widget::{button, column, container, pick_list, row, scrollable, text, text_input, toggler},
 };
+use iced_aw::number_input;
 use log::debug;
-use std::{path::Path, process::Command};
+use std::{
+    ffi::OsString,
+    fs,
+    io::{BufRead, BufReader, Write},
+    os::unix::{net::UnixStream, process::CommandExt},
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    sync::{Mutex, MutexGuard},
+    time::{Duration, Instant},
+};
 use strum::VariantArray;
 
-const GSLAPPER_SOCKET: &str = "/tmp/gslapper.sock";
+const IPC_TIMEOUT: Duration = Duration::from_secs(2);
+const PLAYBACK_TIMEOUT: Duration = Duration::from_secs(6);
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(3);
+const PROBE_INTERVAL: Duration = Duration::from_millis(25);
 
-/// Kill any existing gslapper instance before starting a new one
-fn kill_existing_gslapper() {
-    let socket_path = std::path::Path::new(GSLAPPER_SOCKET);
+// ponytail: lifecycle changes are infrequent, so one global lock is enough;
+// move to per-output locks if real workloads show contention.
+static GSLAPPER_LIFECYCLE: Mutex<()> = Mutex::new(());
 
-    // Try graceful quit via IPC first (using socat if available)
-    if socket_path.exists() {
-        debug!("gSlapper: Attempting graceful quit via IPC");
-        // Try socat first (more commonly available than nc on some systems)
-        let ipc_result = Command::new("bash")
-            .arg("-c")
-            .arg(format!("echo quit | socat - UNIX-CONNECT:{GSLAPPER_SOCKET} 2>/dev/null || echo quit | nc -U {GSLAPPER_SOCKET} 2>/dev/null"))
-            .spawn()
-            .and_then(|mut c| c.wait());
+fn lifecycle_guard() -> anyhow::Result<MutexGuard<'static, ()>> {
+    GSLAPPER_LIFECYCLE
+        .lock()
+        .map_err(|_| anyhow::anyhow!("gSlapper lifecycle lock is poisoned"))
+}
 
-        if ipc_result.is_ok() {
-            // Give it a moment to quit gracefully
-            std::thread::sleep(std::time::Duration::from_millis(200));
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GSlapperStatus {
+    pub paused: bool,
+    pub media_kind: String,
+    pub path: PathBuf,
+}
+
+impl GSlapperStatus {
+    #[must_use]
+    pub fn can_pause(&self) -> bool {
+        self.media_kind == "video" && !self.paused
+    }
+
+    #[must_use]
+    pub fn can_resume(&self) -> bool {
+        self.media_kind == "video" && self.paused
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct GSlapperRuntime {
+    pub status: Option<GSlapperStatus>,
+    pub cache_status: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum GSlapperControl {
+    Pause,
+    Resume,
+    RefreshCache,
+    ClearCache,
+    ClearUnusedCache,
+}
+
+fn canonical_monitor(monitor: &str) -> &str {
+    if monitor == TRANSLATION.get_translation("All") {
+        "*"
+    } else {
+        monitor
+    }
+}
+
+fn stable_output_id(output: &str) -> u64 {
+    // ponytail: FNV-1a keeps socket names stable and short; use a cryptographic
+    // hash if output-name collisions appear in the field.
+    output.bytes().fold(0xcbf29ce484222325, |hash, byte| {
+        (hash ^ u64::from(byte)).wrapping_mul(0x100000001b3)
+    })
+}
+
+fn managed_socket_path_in(root: &Path, monitor: &str) -> PathBuf {
+    root.join(format!(
+        "gslapper-{:016x}.sock",
+        stable_output_id(canonical_monitor(monitor))
+    ))
+}
+
+fn managed_runtime_dir() -> anyhow::Result<PathBuf> {
+    let root = std::env::var_os("XDG_RUNTIME_DIR")
+        .ok_or_else(|| anyhow::anyhow!("XDG_RUNTIME_DIR is not set"))?;
+    let dir = PathBuf::from(root).join("waytrogen");
+    fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+fn managed_socket_path(monitor: &str) -> anyhow::Result<PathBuf> {
+    Ok(managed_socket_path_in(&managed_runtime_dir()?, monitor))
+}
+
+fn is_managed_socket(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with("gslapper-") && name.ends_with(".sock"))
+}
+
+fn overlapping_socket_paths_in(
+    runtime_dir: &Path,
+    monitor: &str,
+    target_socket: &Path,
+) -> anyhow::Result<Vec<PathBuf>> {
+    if canonical_monitor(monitor) == "*" {
+        Ok(fs::read_dir(runtime_dir)?
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|path| path != target_socket && is_managed_socket(path))
+            .collect())
+    } else {
+        let all_socket = managed_socket_path_in(runtime_dir, "*");
+        Ok(all_socket
+            .exists()
+            .then_some(all_socket)
+            .into_iter()
+            .collect())
+    }
+}
+
+fn stop_overlapping_gslappers(
+    runtime_dir: &Path,
+    monitor: &str,
+    target_socket: &Path,
+) -> anyhow::Result<()> {
+    for socket in overlapping_socket_paths_in(runtime_dir, monitor, target_socket)? {
+        stop_gslapper_at(&socket)?;
+    }
+    Ok(())
+}
+
+fn ipc_request_at(socket: &Path, command: &str) -> anyhow::Result<String> {
+    ipc_request_at_with_timeout(socket, command, IPC_TIMEOUT)
+}
+
+fn ipc_request_at_with_timeout(
+    socket: &Path,
+    command: &str,
+    read_timeout: Duration,
+) -> anyhow::Result<String> {
+    if command.contains(['\n', '\r']) {
+        anyhow::bail!("gSlapper IPC commands cannot contain newlines");
+    }
+
+    let mut stream = UnixStream::connect(socket)?;
+    stream.set_read_timeout(Some(read_timeout))?;
+    stream.set_write_timeout(Some(IPC_TIMEOUT))?;
+    stream.write_all(command.as_bytes())?;
+    stream.write_all(b"\n")?;
+
+    let mut response = String::new();
+    BufReader::new(stream).read_line(&mut response)?;
+    let response = response.trim_end_matches(['\r', '\n']);
+    if response.is_empty() {
+        anyhow::bail!("gSlapper returned an empty IPC response");
+    }
+    if let Some(error) = response.strip_prefix("ERROR:") {
+        anyhow::bail!("{}", error.trim());
+    }
+    Ok(response.to_owned())
+}
+
+fn parse_status(response: &str) -> anyhow::Result<GSlapperStatus> {
+    let mut fields = response.trim_end_matches(['\r', '\n']).splitn(4, ' ');
+    if fields.next() != Some("STATUS:") {
+        anyhow::bail!("invalid gSlapper status response");
+    }
+    let paused = match fields.next() {
+        Some("paused") => true,
+        Some("playing") => false,
+        _ => anyhow::bail!("invalid gSlapper playback state"),
+    };
+    let media_kind = fields
+        .next()
+        .filter(|field| matches!(*field, "image" | "video"))
+        .ok_or_else(|| anyhow::anyhow!("invalid gSlapper media type"))?;
+    let path = fields
+        .next()
+        .filter(|field| !field.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("gSlapper status did not include a path"))?;
+    Ok(GSlapperStatus {
+        paused,
+        media_kind: media_kind.to_owned(),
+        path: PathBuf::from(path),
+    })
+}
+
+fn ipc_request(monitor: &str, command: &str) -> anyhow::Result<String> {
+    ipc_request_at(&managed_socket_path(monitor)?, command)
+}
+
+fn ipc_request_with_timeout(
+    monitor: &str,
+    command: &str,
+    read_timeout: Duration,
+) -> anyhow::Result<String> {
+    ipc_request_at_with_timeout(&managed_socket_path(monitor)?, command, read_timeout)
+}
+
+pub fn query_gslapper(monitor: &str) -> anyhow::Result<GSlapperStatus> {
+    parse_status(&ipc_request(monitor, "query")?)
+}
+
+pub fn pause_gslapper(monitor: &str) -> anyhow::Result<()> {
+    ipc_request_with_timeout(monitor, "pause", PLAYBACK_TIMEOUT).map(|_| ())
+}
+
+pub fn resume_gslapper(monitor: &str) -> anyhow::Result<()> {
+    ipc_request_with_timeout(monitor, "resume", PLAYBACK_TIMEOUT).map(|_| ())
+}
+
+pub fn gslapper_cache_stats(monitor: &str) -> anyhow::Result<String> {
+    ipc_request(monitor, "cache-stats")
+}
+
+pub fn clear_gslapper_cache(monitor: &str, unused_only: bool) -> anyhow::Result<()> {
+    let command = if unused_only {
+        "unload unused"
+    } else {
+        "unload all"
+    };
+    ipc_request(monitor, command).map(|_| ())
+}
+
+pub fn load_gslapper_runtime(monitor: &str) -> anyhow::Result<GSlapperRuntime> {
+    let socket = managed_socket_path(monitor)?;
+    if !socket.exists() {
+        return Ok(GSlapperRuntime::default());
+    }
+    Ok(GSlapperRuntime {
+        status: Some(parse_status(&ipc_request_at(&socket, "query")?)?),
+        cache_status: Some(ipc_request_at(&socket, "cache-stats")?),
+    })
+}
+
+pub fn control_gslapper(
+    monitor: &str,
+    control: GSlapperControl,
+) -> anyhow::Result<GSlapperRuntime> {
+    match control {
+        GSlapperControl::Pause => pause_gslapper(monitor)?,
+        GSlapperControl::Resume => resume_gslapper(monitor)?,
+        GSlapperControl::RefreshCache => {}
+        GSlapperControl::ClearCache => clear_gslapper_cache(monitor, false)?,
+        GSlapperControl::ClearUnusedCache => clear_gslapper_cache(monitor, true)?,
+    }
+    load_gslapper_runtime(monitor)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ChangeRecovery {
+    Restart,
+    ReturnError,
+}
+
+fn classify_change_error(error: &str) -> ChangeRecovery {
+    if error.contains("cannot update path (use --auto-stop for video changes)") {
+        ChangeRecovery::Restart
+    } else {
+        ChangeRecovery::ReturnError
+    }
+}
+
+fn media_path_for_ipc(image: &Path) -> anyhow::Result<&str> {
+    let path = image
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("gSlapper IPC requires a UTF-8 media path"))?;
+    if path
+        .as_bytes()
+        .iter()
+        .any(|byte| matches!(byte, b'\n' | b'\r'))
+    {
+        anyhow::bail!("gSlapper media paths cannot contain newlines");
+    }
+    Ok(path)
+}
+
+fn gslapper_help_supports_integration(help: &[u8]) -> bool {
+    let help = String::from_utf8_lossy(help);
+    ["--ipc-socket", "--transition-type", "--cache-size"]
+        .iter()
+        .all(|option| help.contains(option))
+}
+
+pub fn gslapper_is_supported(executable: &Path) -> bool {
+    Command::new(executable)
+        .arg("--help")
+        .output()
+        .is_ok_and(|output| {
+            output.status.success() && gslapper_help_supports_integration(&output.stdout)
+        })
+}
+
+fn ensure_gslapper_is_supported() -> anyhow::Result<()> {
+    if gslapper_is_supported(Path::new("gslapper")) {
+        Ok(())
+    } else {
+        anyhow::bail!("gSlapper 1.5 or newer is required")
+    }
+}
+
+fn launch_args(
+    settings: &GSllaperSettings,
+    socket: &Path,
+    monitor: &str,
+    image: &Path,
+) -> anyhow::Result<Vec<OsString>> {
+    settings.validate().map_err(anyhow::Error::msg)?;
+
+    let mut gst_options = vec![settings.scale_mode.as_arg(), "no-audio"];
+    if settings.loop_video {
+        gst_options.push("loop");
+    }
+    let mut gst_options = gst_options.join(" ");
+    if !settings.additional_options.trim().is_empty() {
+        gst_options.push(' ');
+        gst_options.push_str(settings.additional_options.trim());
+    }
+
+    let mut args = vec![OsString::from("-I"), socket.as_os_str().to_owned()];
+    if let Some(pause_arg) = settings.pause_mode.as_arg() {
+        args.push(OsString::from(pause_arg));
+    }
+    args.extend([
+        OsString::from("-o"),
+        OsString::from(gst_options),
+        OsString::from("-r"),
+        OsString::from(settings.fps_cap.to_string()),
+        OsString::from("--transition-type"),
+        OsString::from(if settings.transition_enabled {
+            "fade"
+        } else {
+            "none"
+        }),
+        OsString::from("--transition-duration"),
+        OsString::from(settings.transition_duration.to_string()),
+        OsString::from("--cache-size"),
+        OsString::from(settings.cache_size_mb.to_string()),
+        OsString::from(canonical_monitor(monitor)),
+        image.as_os_str().to_owned(),
+    ]);
+    Ok(args)
+}
+
+fn wait_for_socket(socket: &Path, child: &mut Child) -> anyhow::Result<()> {
+    let deadline = Instant::now() + STARTUP_TIMEOUT;
+    loop {
+        if ipc_request_at(socket, "query").is_ok() {
+            return Ok(());
+        }
+        if let Some(status) = child.try_wait()? {
+            anyhow::bail!("gSlapper exited before its IPC socket became ready: {status}");
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("gSlapper IPC socket did not become ready");
+        }
+        // ponytail: poll at a fixed short interval; calibrate or add compositor
+        // readiness signalling if real hardware exceeds the startup deadline.
+        std::thread::sleep(PROBE_INTERVAL);
+    }
+}
+
+fn terminate_failed_start(child: &mut Child) -> std::io::Result<()> {
+    if child.try_wait()?.is_none() {
+        child.kill()?;
+        child.wait()?;
+    }
+    Ok(())
+}
+
+fn spawn_managed_process(executable: &Path, args: &[OsString]) -> std::io::Result<Child> {
+    Command::new(executable)
+        .args(args)
+        .process_group(0)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+}
+
+fn spawn_gslapper(
+    settings: &GSllaperSettings,
+    image: &Path,
+    monitor: &str,
+    socket: &Path,
+) -> anyhow::Result<()> {
+    ensure_gslapper_is_supported()?;
+    let args = launch_args(settings, socket, monitor, image)?;
+    debug!("gSlapper: Running command: gslapper {args:?}");
+    let mut child = spawn_managed_process(Path::new("gslapper"), &args)?;
+    if let Err(start_error) = wait_for_socket(socket, &mut child) {
+        if let Err(cleanup_error) = terminate_failed_start(&mut child) {
+            anyhow::bail!(
+                "gSlapper startup failed: {start_error}; failed to clean up its process: {cleanup_error}"
+            );
+        }
+        return Err(start_error);
+    }
+    // ponytail: IPC owns the lifecycle after readiness; a process registry is
+    // unnecessary unless gSlapper needs non-IPC recovery after startup.
+    Ok(())
+}
+
+pub fn apply_gslapper_settings(
+    current: &GSllaperSettings,
+    settings: &GSllaperSettings,
+    monitor: &str,
+) -> anyhow::Result<GSlapperRuntime> {
+    let _guard = lifecycle_guard()?;
+    settings.validate().map_err(anyhow::Error::msg)?;
+    let socket = managed_socket_path(monitor)?;
+    if !socket.exists() {
+        return Ok(GSlapperRuntime::default());
+    }
+    let status = parse_status(&ipc_request_at(&socket, "query")?)?;
+
+    if current.launch_settings_changed(settings) {
+        ensure_gslapper_is_supported()?;
+        stop_gslapper_at(&socket)?;
+        if let Err(start_error) = spawn_gslapper(settings, &status.path, monitor, &socket) {
+            if let Err(rollback_error) = spawn_gslapper(current, &status.path, monitor, &socket) {
+                anyhow::bail!(
+                    "new gSlapper settings failed: {start_error}; restoring the previous settings also failed: {rollback_error}"
+                );
+            }
+            anyhow::bail!(
+                "new gSlapper settings failed; restored previous settings: {start_error}"
+            );
+        }
+    } else {
+        if current.transition_enabled != settings.transition_enabled {
+            ipc_request_at(
+                &socket,
+                if settings.transition_enabled {
+                    "set-transition fade"
+                } else {
+                    "set-transition none"
+                },
+            )?;
+        }
+        if current.transition_duration != settings.transition_duration {
+            ipc_request_at(
+                &socket,
+                &format!("set-transition-duration {}", settings.transition_duration),
+            )?;
         }
     }
+    load_gslapper_runtime(monitor)
+}
 
-    // Always use pkill as fallback/confirmation to ensure process is dead
-    debug!("gSlapper: Ensuring process is killed with pkill");
-    let _ = Command::new("pkill")
-        .arg("-9")
-        .arg("gslapper")
-        .spawn()
-        .and_then(|mut c| c.wait());
-
-    // Small delay to ensure process is fully terminated
-    std::thread::sleep(std::time::Duration::from_millis(100));
-
-    // Clean up socket file if it still exists
-    if socket_path.exists() {
-        let _ = std::fs::remove_file(GSLAPPER_SOCKET);
+fn stop_gslapper_at(socket: &Path) -> anyhow::Result<()> {
+    if !socket.exists() {
+        return Ok(());
     }
+    if let Err(error) = ipc_request_at(socket, "stop") {
+        if UnixStream::connect(socket).is_err() {
+            fs::remove_file(socket)?;
+            return Ok(());
+        }
+        return Err(error);
+    }
+
+    let deadline = Instant::now() + STARTUP_TIMEOUT;
+    loop {
+        if !socket.exists() {
+            return Ok(());
+        }
+        if UnixStream::connect(socket).is_err() {
+            fs::remove_file(socket)?;
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("gSlapper did not release its IPC socket after stop");
+        }
+        std::thread::sleep(PROBE_INTERVAL);
+    }
+}
+
+pub fn stop_gslapper(monitor: &str) -> anyhow::Result<()> {
+    let _guard = lifecycle_guard()?;
+    stop_gslapper_at(&managed_socket_path(monitor)?)
+}
+
+pub fn stop_all_managed_gslappers() -> anyhow::Result<()> {
+    let _guard = lifecycle_guard()?;
+    let runtime_dir = managed_runtime_dir()?;
+    let mut first_error = None;
+    for entry in fs::read_dir(runtime_dir)? {
+        let path = entry?.path();
+        if is_managed_socket(&path)
+            && let Err(error) = stop_gslapper_at(&path)
+            && first_error.is_none()
+        {
+            first_error = Some(error);
+        }
+    }
+    first_error.map_or(Ok(()), Err)
 }
 
 pub fn change_gslapper_wallpaper(
     gslapper_changer: &WallpaperChangers,
     image: &Path,
     monitor: &str,
-) {
-    if let WallpaperChangers::GSlapper(settings) = gslapper_changer {
-        debug!("gSlapper: Setting wallpaper {}", image.display());
+) -> anyhow::Result<()> {
+    let _guard = lifecycle_guard()?;
+    let WallpaperChangers::GSlapper(settings) = gslapper_changer else {
+        anyhow::bail!("gSlapper backend called with another wallpaper changer");
+    };
+    let socket = managed_socket_path(monitor)?;
+    let runtime_dir = socket
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("managed gSlapper socket has no runtime directory"))?;
+    stop_overlapping_gslappers(runtime_dir, monitor, &socket)?;
+    let media_path = media_path_for_ipc(image)?;
 
-        // Kill any existing gslapper instance first
-        kill_existing_gslapper();
+    if !socket.exists() {
+        return spawn_gslapper(settings, image, monitor, &socket);
+    }
 
-        // Build gslapper options
-        let mut gst_options = Vec::new();
-
-        // Add scale mode
-        gst_options.push(settings.scale_mode.to_string());
-
-        // Add loop if enabled
-        if settings.loop_video {
-            gst_options.push("loop".to_owned());
+    if let Err(error) = ipc_request_at(&socket, "query") {
+        if UnixStream::connect(&socket).is_ok() {
+            return Err(error);
         }
+        fs::remove_file(&socket)?;
+        return spawn_gslapper(settings, image, monitor, &socket);
+    }
 
-        // Always disable audio for wallpapers
-        gst_options.push("no-audio".to_owned());
-
-        // Add any additional user-provided options
-        if !settings.additional_options.is_empty() {
-            gst_options.push(settings.additional_options.clone());
+    match ipc_request_at(&socket, &format!("change {media_path}")) {
+        Ok(_) => Ok(()),
+        Err(error) if classify_change_error(&error.to_string()) == ChangeRecovery::Restart => {
+            stop_gslapper_at(&socket)?;
+            spawn_gslapper(settings, image, monitor, &socket)
         }
-
-        let gst_options_str = gst_options.join(" ");
-
-        let mut command = Command::new("gslapper");
-
-        // Add IPC socket for future control
-        command.arg("-I").arg(GSLAPPER_SOCKET);
-
-        // Add pause mode
-        match settings.pause_mode {
-            GSllapperPauseMode::None => {}
-            GSllapperPauseMode::AutoPause => {
-                command.arg("-p");
-            }
-            GSllapperPauseMode::AutoStop => {
-                command.arg("-s");
-            }
-        }
-
-        // Add GStreamer options
-        command.arg("-o").arg(&gst_options_str);
-
-        // Fork to background
-        command.arg("-f");
-
-        // Add monitor (use '*' for all monitors)
-        let monitor_arg = if monitor == TRANSLATION.get_translation("All") {
-            "*"
-        } else {
-            monitor
-        };
-        command.arg(monitor_arg);
-
-        // Add the wallpaper path
-        command.arg(image);
-
-        debug!("gSlapper: Running command: {command:?}");
-
-        command.spawn().unwrap().wait_with_output().unwrap();
+        Err(error) => Err(error),
     }
 }
 
 pub fn generate_gslapper_changer_bar(app_state: AppState) -> Vec<Element<'static, Messages>> {
-    let scale_mode_dropdown: Element<'_, Messages> = create_tooltip(
-        pick_list(
-            GSllapperScaleMode::VARIANTS,
-            app_state.gslapper_scale_mode,
-            Messages::GSllaperScaleModeChanged,
-        )
-        .into(),
-        text![
-            "{}",
-            TRANSLATION.get_translation("gslapper-scale-mode-tooltip")
-        ]
-        .into(),
-    )
-    .into();
-
-    let pause_mode_dropdown: Element<'_, Messages> = create_tooltip(
-        pick_list(
-            GSllapperPauseMode::VARIANTS,
-            app_state.gslapper_pause_mode,
-            Messages::GSlapperPauseModeChanged,
-        )
-        .into(),
-        text![
-            "{}",
-            TRANSLATION.get_translation("gslapper-pause-mode-tooltip")
-        ]
-        .into(),
-    )
-    .into();
-
-    let loop_switch: Element<'_, Messages> = create_tooltip(
-        toggler(app_state.gslapper_loop)
-            .on_toggle(Messages::GSllaperLoopVideoChanged)
+    let mut elements: Vec<Element<'static, Messages>> = vec![
+        create_tooltip(
+            button(text![
+                "{}",
+                TRANSLATION.get_translation("gslapper-settings")
+            ])
+            .on_press(Messages::OpenGSlapperSettings)
             .into(),
+            text![
+                "{}",
+                TRANSLATION.get_translation("gslapper-settings-tooltip")
+            ]
+            .into(),
+        )
+        .into(),
+    ];
+    if let Some(error) = app_state.gslapper_error {
+        elements.push(text(error).style(text::danger).into());
+    }
+    elements
+}
+
+pub fn generate_gslapper_settings_dialog(app_state: &AppState) -> Element<'_, Messages> {
+    let Some(settings) = app_state.gslapper_settings_draft.as_ref() else {
+        return column![].into();
+    };
+
+    let mut playback_controls = row![].spacing(10).align_y(Alignment::Center);
+    let mut pause = button(text!["{}", TRANSLATION.get_translation("gslapper-pause")]);
+    let mut resume = button(text!["{}", TRANSLATION.get_translation("gslapper-resume")]);
+    if let Some(status) = &app_state.gslapper_status {
+        if status.can_pause() {
+            pause = pause.on_press(Messages::GSlapperControlRequested(GSlapperControl::Pause));
+        }
+        if status.can_resume() {
+            resume = resume.on_press(Messages::GSlapperControlRequested(GSlapperControl::Resume));
+        }
+    }
+    playback_controls = playback_controls.push(pause).push(resume);
+
+    let status: Element<'_, Messages> = if let Some(status) = &app_state.gslapper_status {
+        column![
+            text![
+                "{}: {}",
+                if status.paused {
+                    TRANSLATION.get_translation("gslapper-paused")
+                } else {
+                    TRANSLATION.get_translation("gslapper-playing")
+                },
+                status.media_kind
+            ],
+            text(status.path.to_string_lossy()),
+            playback_controls,
+        ]
+        .spacing(6)
+        .into()
+    } else {
+        text!["{}", TRANSLATION.get_translation("gslapper-not-running")].into()
+    };
+
+    let behavior = column![
         text![
             "{}",
-            TRANSLATION.get_translation("gslapper-loop-video-tooltip")
+            TRANSLATION.get_translation("gslapper-wallpaper-behavior")
         ]
-        .into(),
-    )
-    .into();
-
-    let additional_options_entry: Element<'_, Messages> = text_input(
-        &TRANSLATION.get_translation("gslapper-additional-option"),
-        &app_state.gslapper_additional_options,
-    )
-    .on_input(Messages::GSllaperAdditionalOptionsChanged)
-    .into();
-
-    vec![
-        scale_mode_dropdown,
-        pause_mode_dropdown,
-        loop_switch,
-        additional_options_entry,
+        .size(18),
+        row![
+            text!["{}", TRANSLATION.get_translation("gslapper-scale-mode")],
+            pick_list(
+                GSllapperScaleMode::VARIANTS,
+                Some(settings.scale_mode.clone()),
+                Messages::GSllaperScaleModeChanged,
+            ),
+        ]
+        .spacing(10)
+        .align_y(Alignment::Center),
+        row![
+            text!["{}", TRANSLATION.get_translation("gslapper-loop-video")],
+            toggler(settings.loop_video).on_toggle(Messages::GSllaperLoopVideoChanged),
+        ]
+        .spacing(10)
+        .align_y(Alignment::Center),
+        row![
+            text![
+                "{}",
+                TRANSLATION.get_translation("gslapper-hidden-playback")
+            ],
+            pick_list(
+                GSllapperPauseMode::VARIANTS,
+                Some(settings.pause_mode.clone()),
+                Messages::GSlapperPauseModeChanged,
+            ),
+        ]
+        .spacing(10)
+        .align_y(Alignment::Center),
     ]
+    .spacing(8);
+
+    let transitions = column![
+        text!["{}", TRANSLATION.get_translation("gslapper-transitions")].size(18),
+        row![
+            text![
+                "{}",
+                TRANSLATION.get_translation("gslapper-enable-transition")
+            ],
+            toggler(settings.transition_enabled)
+                .on_toggle(Messages::GSlapperTransitionEnabledChanged),
+        ]
+        .spacing(10)
+        .align_y(Alignment::Center),
+        row![
+            text![
+                "{}",
+                TRANSLATION.get_translation("gslapper-transition-duration")
+            ],
+            number_input(
+                &settings.transition_duration,
+                0.1..=5.0,
+                Messages::GSlapperTransitionDurationChanged,
+            )
+            .step(0.1),
+        ]
+        .spacing(10)
+        .align_y(Alignment::Center),
+    ]
+    .spacing(8);
+
+    let mut content = column![
+        text!["{}", TRANSLATION.get_translation("gslapper-settings")].size(24),
+        text![
+            "{}",
+            TRANSLATION.get_translation("gslapper-settings-description")
+        ],
+        text![
+            "{}: {}",
+            TRANSLATION.get_translation("gslapper-output"),
+            app_state.monitor.as_deref().unwrap_or("-")
+        ],
+        text!["{}", TRANSLATION.get_translation("gslapper-status")].size(18),
+        status,
+        behavior,
+        transitions,
+        button(text![
+            "{}",
+            if app_state.show_gslapper_advanced {
+                TRANSLATION.get_translation("gslapper-hide-advanced")
+            } else {
+                TRANSLATION.get_translation("gslapper-show-advanced")
+            }
+        ])
+        .on_press(Messages::ToggleGSlapperAdvanced),
+    ]
+    .spacing(12)
+    .width(Length::Fill);
+
+    if app_state.show_gslapper_advanced {
+        let cache_status = app_state
+            .gslapper_cache_status
+            .clone()
+            .unwrap_or_else(|| TRANSLATION.get_translation("gslapper-cache-unavailable"));
+        let mut refresh = button(text![
+            "{}",
+            TRANSLATION.get_translation("gslapper-cache-refresh")
+        ]);
+        let mut clear_unused = button(text![
+            "{}",
+            TRANSLATION.get_translation("gslapper-cache-clear-unused")
+        ]);
+        let mut clear_all = button(text![
+            "{}",
+            TRANSLATION.get_translation("gslapper-cache-clear-all")
+        ]);
+        if app_state.gslapper_status.is_some() {
+            refresh = refresh.on_press(Messages::GSlapperControlRequested(
+                GSlapperControl::RefreshCache,
+            ));
+            clear_unused = clear_unused.on_press(Messages::GSlapperControlRequested(
+                GSlapperControl::ClearUnusedCache,
+            ));
+            clear_all = clear_all.on_press(Messages::GSlapperControlRequested(
+                GSlapperControl::ClearCache,
+            ));
+        }
+        content = content.push(
+            column![
+                row![
+                    text!["{}", TRANSLATION.get_translation("gslapper-fps-cap")],
+                    pick_list(
+                        [30_u16, 60, 100],
+                        Some(settings.fps_cap),
+                        Messages::GSlapperFpsChanged,
+                    ),
+                ]
+                .spacing(10)
+                .align_y(Alignment::Center),
+                row![
+                    text!["{}", TRANSLATION.get_translation("gslapper-cache-size")],
+                    number_input(
+                        &settings.cache_size_mb,
+                        0..=i32::MAX as u32,
+                        Messages::GSlapperCacheSizeChanged,
+                    ),
+                ]
+                .spacing(10)
+                .align_y(Alignment::Center),
+                text![
+                    "{}: {}",
+                    TRANSLATION.get_translation("gslapper-cache-status"),
+                    cache_status
+                ],
+                row![refresh, clear_unused, clear_all,].spacing(8),
+                text!["{}", TRANSLATION.get_translation("gslapper-raw-options")],
+                text![
+                    "{}",
+                    TRANSLATION.get_translation("gslapper-raw-options-help")
+                ]
+                .size(12),
+                text_input(
+                    &TRANSLATION.get_translation("gslapper-additional-option"),
+                    &settings.additional_options,
+                )
+                .on_input(Messages::GSllaperAdditionalOptionsChanged),
+            ]
+            .spacing(8),
+        );
+    }
+
+    if let Some(error) = &app_state.gslapper_error {
+        content = content.push(text(error).style(text::danger));
+    }
+    content = content.push(
+        row![
+            button(text!["{}", TRANSLATION.get_translation("gslapper-cancel")])
+                .on_press(Messages::CloseGSlapperSettings),
+            button(text!["{}", TRANSLATION.get_translation("gslapper-save")])
+                .on_press(Messages::SaveGSlapperSettings),
+        ]
+        .spacing(10),
+    );
+
+    container(scrollable(content).height(Length::Fill))
+        .padding(20)
+        .width(620)
+        .max_height(720)
+        .style(container::bordered_box)
+        .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wallpaper_changers::GSllaperSettings;
+    use std::{
+        fs,
+        io::{BufRead, Write},
+        os::unix::net::UnixListener,
+        path::PathBuf,
+        sync::atomic::{AtomicU64, Ordering},
+        sync::mpsc,
+        thread,
+    };
+
+    static TEST_SOCKET_ID: AtomicU64 = AtomicU64::new(0);
+
+    fn test_listener() -> (PathBuf, UnixListener, PathBuf) {
+        let root = std::env::temp_dir().join(format!(
+            "waytrogen-gslapper-test-{}-{}",
+            std::process::id(),
+            TEST_SOCKET_ID.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let socket = root.join("ipc.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        (socket, listener, root)
+    }
+
+    #[test]
+    fn socket_paths_are_owned_and_output_specific() {
+        let root = Path::new("/run/user/1000/waytrogen");
+        let first = managed_socket_path_in(root, "DP-1");
+        let second = managed_socket_path_in(root, "HDMI-A-1");
+        assert_ne!(first, second);
+        assert_eq!(first.parent(), Some(root));
+        assert!(
+            first
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .ends_with(".sock")
+        );
+    }
+
+    #[test]
+    fn wallpaper_changes_are_serialized() {
+        let guard = lifecycle_guard().unwrap();
+        let (sender, receiver) = mpsc::channel();
+        let waiter = thread::spawn(move || {
+            let result = change_gslapper_wallpaper(
+                &WallpaperChangers::Swaybg(Default::default()),
+                Path::new("/tmp/not-used"),
+                "DP-1",
+            );
+            sender.send(result.is_err()).unwrap();
+        });
+
+        assert!(receiver.recv_timeout(Duration::from_millis(50)).is_err());
+        drop(guard);
+        assert!(receiver.recv_timeout(Duration::from_secs(1)).unwrap());
+        waiter.join().unwrap();
+    }
+
+    #[test]
+    fn all_and_specific_outputs_select_only_overlapping_sockets() {
+        let root = std::env::temp_dir().join(format!(
+            "waytrogen-gslapper-overlap-test-{}-{}",
+            std::process::id(),
+            TEST_SOCKET_ID.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let all = managed_socket_path_in(&root, "*");
+        let dp = managed_socket_path_in(&root, "DP-1");
+        let hdmi = managed_socket_path_in(&root, "HDMI-A-1");
+        fs::File::create(&all).unwrap();
+        fs::File::create(&dp).unwrap();
+        fs::File::create(&hdmi).unwrap();
+
+        let for_all = overlapping_socket_paths_in(&root, "*", &all).unwrap();
+        assert_eq!(for_all.len(), 2);
+        assert!(for_all.contains(&dp));
+        assert!(for_all.contains(&hdmi));
+        assert_eq!(
+            overlapping_socket_paths_in(&root, "DP-1", &dp).unwrap(),
+            vec![all]
+        );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn query_parser_preserves_spaces_in_paths() {
+        let status = parse_status("STATUS: paused image /wallpapers/space name.png\n").unwrap();
+        assert!(status.paused);
+        assert_eq!(status.path, PathBuf::from("/wallpapers/space name.png"));
+
+        let status = parse_status("STATUS: playing image /wallpapers/trailing  \n").unwrap();
+        assert_eq!(status.path, PathBuf::from("/wallpapers/trailing  "));
+    }
+
+    #[test]
+    fn ipc_request_writes_one_command_and_reads_response() {
+        let (socket, listener, root) = test_listener();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut command = String::new();
+            std::io::BufReader::new(&mut stream)
+                .read_line(&mut command)
+                .unwrap();
+            assert_eq!(command, "query\n");
+            stream
+                .write_all(b"STATUS: playing image /tmp/a.png\n")
+                .unwrap();
+        });
+
+        let response = ipc_request_at(&socket, "query").unwrap();
+        server.join().unwrap();
+        assert!(response.starts_with("STATUS:"));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn ipc_response_does_not_require_connection_eof() {
+        let (socket, listener, root) = test_listener();
+        let (release_sender, release_receiver) = mpsc::channel();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut command = String::new();
+            std::io::BufReader::new(&mut stream)
+                .read_line(&mut command)
+                .unwrap();
+            assert_eq!(command, "query\n");
+            stream
+                .write_all(b"STATUS: playing image /tmp/a.png\n")
+                .unwrap();
+            release_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap();
+        });
+
+        let response = ipc_request_at_with_timeout(&socket, "query", Duration::from_millis(50));
+        release_sender.send(()).unwrap();
+        server.join().unwrap();
+        assert_eq!(response.unwrap(), "STATUS: playing image /tmp/a.png");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn ipc_request_returns_protocol_errors() {
+        let (socket, listener, root) = test_listener();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut command = String::new();
+            std::io::BufReader::new(&mut stream)
+                .read_line(&mut command)
+                .unwrap();
+            stream.write_all(b"ERROR: no pipeline\n").unwrap();
+        });
+
+        let error = ipc_request_at(&socket, "query").unwrap_err();
+        server.join().unwrap();
+        assert!(error.to_string().contains("no pipeline"));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn launch_args_include_gslapper_1_5_settings() {
+        let settings = GSllaperSettings {
+            scale_mode: GSllapperScaleMode::Stretch,
+            pause_mode: GSllapperPauseMode::AutoStop,
+            fps_cap: 60,
+            transition_enabled: true,
+            transition_duration: 0.75,
+            cache_size_mb: 128,
+            ..GSllaperSettings::default()
+        };
+        let args = launch_args(
+            &settings,
+            Path::new("/tmp/socket.sock"),
+            "DP-1",
+            Path::new("/tmp/wallpaper.mp4"),
+        )
+        .unwrap();
+        let args: Vec<String> = args
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+
+        assert!(args.windows(2).any(|pair| pair == ["-r", "60"]));
+        assert!(args.windows(2).any(|pair| pair == ["--cache-size", "128"]));
+        assert!(args.iter().any(|arg| arg == "-s"));
+        assert!(args.iter().any(|arg| arg == "stretch no-audio loop"));
+        assert!(!args.iter().any(|arg| arg == "-f"));
+    }
+
+    #[test]
+    fn failed_start_terminates_owned_child() {
+        let mut child = Command::new("sleep").arg("10").spawn().unwrap();
+        terminate_failed_start(&mut child).unwrap();
+        assert!(child.try_wait().unwrap().is_some());
+    }
+
+    fn process_group_id(pid: u32) -> u32 {
+        let stat = fs::read_to_string(format!("/proc/{pid}/stat")).unwrap();
+        stat.rsplit_once(") ")
+            .unwrap()
+            .1
+            .split_whitespace()
+            .nth(2)
+            .unwrap()
+            .parse()
+            .unwrap()
+    }
+
+    #[test]
+    fn managed_child_uses_own_process_group() {
+        let args = [OsString::from("10")];
+        let mut child = spawn_managed_process(Path::new("sleep"), &args).unwrap();
+        let child_pid = child.id();
+        let child_process_group = process_group_id(child_pid);
+        terminate_failed_start(&mut child).unwrap();
+
+        assert_eq!(child_process_group, child_pid);
+    }
+
+    #[test]
+    fn startup_reports_child_exit_before_socket_timeout() {
+        let socket = std::env::temp_dir().join(format!(
+            "waytrogen-missing-gslapper-socket-{}-{}",
+            std::process::id(),
+            TEST_SOCKET_ID.fetch_add(1, Ordering::Relaxed)
+        ));
+        let mut child = Command::new("true").spawn().unwrap();
+
+        let error = wait_for_socket(&socket, &mut child).unwrap_err();
+
+        assert!(error.to_string().contains("exited before"));
+    }
+
+    #[test]
+    fn compatibility_check_requires_gslapper_1_5_features() {
+        let current = b"--ipc-socket PATH --transition-type TYPE --cache-size MB";
+        let old = b"--ipc-socket PATH --auto-stop";
+        assert!(gslapper_help_supports_integration(current));
+        assert!(!gslapper_help_supports_integration(old));
+    }
+
+    #[test]
+    fn video_change_error_selects_one_restart() {
+        assert_eq!(
+            classify_change_error("cannot update path (use --auto-stop for video changes)"),
+            ChangeRecovery::Restart
+        );
+        assert_eq!(
+            classify_change_error("file not accessible"),
+            ChangeRecovery::ReturnError
+        );
+    }
+
+    #[test]
+    fn playback_controls_follow_runtime_status() {
+        let mut status = GSlapperStatus {
+            paused: false,
+            media_kind: "video".to_owned(),
+            path: PathBuf::from("wallpaper.mp4"),
+        };
+
+        assert!(status.can_pause());
+        assert!(!status.can_resume());
+
+        status.paused = true;
+        assert!(!status.can_pause());
+        assert!(status.can_resume());
+
+        status.media_kind = "image".to_owned();
+        assert!(!status.can_pause());
+        assert!(!status.can_resume());
+    }
+
+    #[test]
+    fn playback_timeout_exceeds_gslapper_state_wait() {
+        assert!(PLAYBACK_TIMEOUT > Duration::from_secs(5));
+    }
+
+    #[test]
+    fn stop_waits_until_the_socket_is_released() {
+        let (socket, listener, root) = test_listener();
+        let server_socket = socket.clone();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut command = String::new();
+            std::io::BufReader::new(&mut stream)
+                .read_line(&mut command)
+                .unwrap();
+            assert_eq!(command, "stop\n");
+            stream.write_all(b"OK\n").unwrap();
+            drop(stream);
+            drop(listener);
+            thread::sleep(Duration::from_millis(50));
+            let _ = fs::remove_file(server_socket);
+        });
+
+        stop_gslapper_at(&socket).unwrap();
+        server.join().unwrap();
+        assert!(!socket.exists());
+        fs::remove_dir_all(root).unwrap();
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,7 +29,7 @@ pub fn restore_wallpapers(app_state: &AppState) -> anyhow::Result<()> {
         wallpaper.clone().changer.change(
             PathBuf::from(wallpaper.clone().path),
             wallpaper.clone().monitor,
-        );
+        )?;
         match wallpaper.clone().changer {
             WallpaperChangers::Hyprpaper(_) => {
                 thread::sleep(Duration::from_secs(1));
@@ -91,7 +91,7 @@ pub fn set_random_wallpapers(app_state: &mut AppState) -> anyhow::Result<()> {
         log::debug!("{index}");
         w.changer
             .clone()
-            .change(files[index].clone(), w.monitor.clone());
+            .change(files[index].clone(), w.monitor.clone())?;
         files[index]
             .clone()
             .to_str()
@@ -122,7 +122,7 @@ pub fn cycle_next_wallpaper(args: &Cli, app_state: &mut AppState) -> anyhow::Res
                         .parse::<PathBuf>()
                         .unwrap_or_default()
             });
-            try_set_next_wallpaper(&files, wallpaper_index, previous_wallpaper);
+            try_set_next_wallpaper(&files, wallpaper_index, previous_wallpaper)?;
         }
     } else {
         let previous_wallpaper = previous_wallpapers
@@ -145,7 +145,7 @@ pub fn cycle_next_wallpaper(args: &Cli, app_state: &mut AppState) -> anyhow::Res
                     .unwrap_or_default()
             }),
             &mut previous_wallpaper,
-        );
+        )?;
         let index = previous_wallpapers
             .iter()
             .position(|w| w.monitor == previous_wallpaper.monitor)
@@ -160,13 +160,13 @@ fn try_set_next_wallpaper(
     files: &[PathBuf],
     position: Option<usize>,
     previous_wallpaper: &mut Wallpaper,
-) {
+) -> anyhow::Result<()> {
     if let Some(i) = position {
         let path = &files[(i + 1) % files.len()];
         previous_wallpaper
             .changer
             .clone()
-            .change(path.clone(), previous_wallpaper.monitor.clone());
+            .change(path.clone(), previous_wallpaper.monitor.clone())?;
         path.to_str()
             .unwrap_or_default()
             .clone_into(&mut previous_wallpaper.path);
@@ -184,7 +184,7 @@ fn try_set_next_wallpaper(
                 previous_wallpaper
                     .changer
                     .clone()
-                    .change(p.clone(), previous_wallpaper.monitor.clone());
+                    .change(p.clone(), previous_wallpaper.monitor.clone())?;
                 p.to_str()
                     .unwrap_or_default()
                     .clone_into(&mut previous_wallpaper.path);
@@ -196,6 +196,7 @@ fn try_set_next_wallpaper(
             }
         }
     }
+    Ok(())
 }
 
 pub fn delete_image_cache() -> anyhow::Result<()> {
@@ -233,4 +234,3 @@ pub fn delete_image_cache() -> anyhow::Result<()> {
         }
     }
 }
-

--- a/src/wallpaper_changers.rs
+++ b/src/wallpaper_changers.rs
@@ -2,7 +2,10 @@ use crate::{
     app_state::{AppState, Messages},
     changers::{
         awww::{change_awww_wallpaper, generate_awww_changer_bar},
-        gslapper::{change_gslapper_wallpaper, generate_gslapper_changer_bar},
+        gslapper::{
+            change_gslapper_wallpaper, generate_gslapper_changer_bar, gslapper_is_supported,
+            stop_all_managed_gslappers, stop_gslapper,
+        },
         hyprpaper::{change_hyprpaper_wallpaper, generate_hyprpaper_changer_bar},
         mpvpaper::{change_mpvpaper_wallpaper, generate_mpvpaper_changer_bar},
         swaybg::{change_swaybg_wallpaper, generate_swaybg_changer_bar},
@@ -18,9 +21,9 @@ use strum_macros::{EnumIter, IntoStaticStr};
 use which::which;
 
 pub trait WallpaperChanger {
-    fn change(self, image: PathBuf, monitor: String);
+    fn change(self, image: PathBuf, monitor: String) -> anyhow::Result<()>;
     fn accepted_formats(&self) -> Vec<String>;
-    fn kill(&self);
+    fn kill(&self, monitor: Option<&str>);
     fn ui_elements(&self, app_state: AppState) -> Vec<Element<'_, Messages>>;
 }
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Default)]
@@ -78,12 +81,59 @@ impl Default for AwwwSettings {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Default)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[serde(default)]
 pub struct GSllaperSettings {
     pub scale_mode: GSllapperScaleMode,
     pub pause_mode: GSllapperPauseMode,
     pub loop_video: bool,
     pub additional_options: String,
+    pub fps_cap: u16,
+    pub transition_enabled: bool,
+    pub transition_duration: f64,
+    pub cache_size_mb: u32,
+}
+
+impl Default for GSllaperSettings {
+    fn default() -> Self {
+        Self {
+            scale_mode: GSllapperScaleMode::default(),
+            pause_mode: GSllapperPauseMode::default(),
+            loop_video: true,
+            additional_options: String::new(),
+            fps_cap: 30,
+            transition_enabled: false,
+            transition_duration: 0.5,
+            cache_size_mb: 256,
+        }
+    }
+}
+
+impl GSllaperSettings {
+    pub fn validate(&self) -> Result<(), String> {
+        if !matches!(self.fps_cap, 30 | 60 | 100) {
+            return Err("gSlapper FPS cap must be 30, 60, or 100".to_owned());
+        }
+        if !(self.transition_duration > 0.0 && self.transition_duration <= 5.0) {
+            return Err(
+                "gSlapper transition duration must be above 0 and at most 5 seconds".to_owned(),
+            );
+        }
+        if self.cache_size_mb > i32::MAX as u32 {
+            return Err("gSlapper cache size exceeds the supported integer range".to_owned());
+        }
+        Ok(())
+    }
+
+    #[must_use]
+    pub fn launch_settings_changed(&self, other: &Self) -> bool {
+        self.scale_mode != other.scale_mode
+            || self.pause_mode != other.pause_mode
+            || self.loop_video != other.loop_video
+            || self.additional_options != other.additional_options
+            || self.fps_cap != other.fps_cap
+            || self.cache_size_mb != other.cache_size_mb
+    }
 }
 
 #[derive(Debug, EnumIter, Clone, Serialize, Deserialize, PartialEq)]
@@ -102,6 +152,18 @@ pub enum GSllapperScaleMode {
     Stretch,
     Original,
     Panscan,
+}
+
+impl GSllapperScaleMode {
+    #[must_use]
+    pub const fn as_arg(&self) -> &'static str {
+        match self {
+            Self::Fill => "fill",
+            Self::Stretch => "stretch",
+            Self::Original => "original",
+            Self::Panscan => "panscan",
+        }
+    }
 }
 
 impl Display for GSllapperScaleMode {
@@ -137,6 +199,17 @@ pub enum GSllapperPauseMode {
     AutoStop,
 }
 
+impl GSllapperPauseMode {
+    #[must_use]
+    pub const fn as_arg(&self) -> Option<&'static str> {
+        match self {
+            Self::None => None,
+            Self::AutoPause => Some("-p"),
+            Self::AutoStop => Some("-s"),
+        }
+    }
+}
+
 impl Display for GSllapperPauseMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -169,10 +242,10 @@ impl Default for WallpaperChangers {
 impl WallpaperChangers {
     pub fn killall_changers() {
         for changer in WallpaperChangers::iter() {
-            changer.kill();
+            changer.kill(None);
         }
     }
-    fn kill_all_changers_except(changer: &WallpaperChangers) {
+    fn kill_all_changers_except(changer: &WallpaperChangers, monitor: &str) {
         let varient = match changer {
             Self::Hyprpaper(_) => Self::Hyprpaper(HyprpaperSettings::default()),
             Self::Swaybg(_) => Self::Swaybg(SwaybgSettings::default()),
@@ -182,7 +255,7 @@ impl WallpaperChangers {
         };
         WallpaperChangers::iter().for_each(|w| {
             if w != varient {
-                w.kill();
+                w.kill(Some(monitor));
             }
         });
     }
@@ -460,24 +533,26 @@ impl Display for MpvPaperPauseModes {
 }
 
 impl WallpaperChanger for WallpaperChangers {
-    fn change(self, image: PathBuf, monitor: String) {
-        Self::kill_all_changers_except(&self);
+    fn change(self, image: PathBuf, monitor: String) -> anyhow::Result<()> {
+        Self::kill_all_changers_except(&self, &monitor);
         match self {
             Self::Hyprpaper(_) => {
                 change_hyprpaper_wallpaper(self, &image, &monitor);
+                Ok(())
             }
             Self::Swaybg(_) => {
                 change_swaybg_wallpaper(self, &image, &monitor);
+                Ok(())
             }
             Self::MpvPaper(_) => {
                 change_mpvpaper_wallpaper(&self, &image, &monitor);
+                Ok(())
             }
             Self::Awww(_) => {
                 change_awww_wallpaper(self, image, monitor);
+                Ok(())
             }
-            Self::GSlapper(_) => {
-                change_gslapper_wallpaper(&self, &image, &monitor);
-            }
+            Self::GSlapper(_) => change_gslapper_wallpaper(&self, &image, &monitor),
         }
     }
 
@@ -845,10 +920,6 @@ impl WallpaperChanger for WallpaperChangers {
                     "jpeg".to_owned(),
                     "png".to_owned(),
                     "webp".to_owned(),
-                    "gif".to_owned(),
-                    "bmp".to_owned(),
-                    "tiff".to_owned(),
-                    "tif".to_owned(),
                     // Videos (common formats supported by GStreamer)
                     "mp4".to_owned(),
                     "mkv".to_owned(),
@@ -872,7 +943,7 @@ impl WallpaperChanger for WallpaperChangers {
             }
         }
     }
-    fn kill(&self) {
+    fn kill(&self, monitor: Option<&str>) {
         match self {
             Self::Hyprpaper(_) => {
                 let _ = Command::new("pkill")
@@ -903,25 +974,13 @@ impl WallpaperChanger for WallpaperChangers {
                     .and_then(|mut c| c.wait());
             }
             Self::GSlapper(_) => {
-                // Try graceful quit via IPC first (using socat or nc)
-                let socket_path = "/tmp/gslapper.sock";
-                if std::path::Path::new(socket_path).exists() {
-                    let _ = Command::new("bash")
-                        .arg("-c")
-                        .arg(format!("echo quit | socat - UNIX-CONNECT:{socket_path} 2>/dev/null || echo quit | nc -U {socket_path} 2>/dev/null"))
-                        .spawn()
-                        .and_then(|mut c| c.wait());
-                    // Give it a moment to quit gracefully
-                    std::thread::sleep(std::time::Duration::from_millis(200));
+                let result = match monitor {
+                    Some(monitor) => stop_gslapper(monitor),
+                    None => stop_all_managed_gslappers(),
+                };
+                if let Err(error) = result {
+                    log::warn!("Failed to stop managed gSlapper: {error}");
                 }
-                // Always pkill to ensure process is dead
-                let _ = Command::new("pkill")
-                    .arg("-9")
-                    .arg("gslapper")
-                    .spawn()
-                    .and_then(|mut c| c.wait());
-                // Clean up socket
-                let _ = std::fs::remove_file(socket_path);
             }
         }
     }
@@ -974,10 +1033,16 @@ pub fn get_available_wallpaper_changers() -> Vec<WallpaperChangers> {
                     }
                 }
             },
+            WallpaperChangers::GSlapper(_) => {
+                if let Ok(executable) = which(changer.to_string().to_lowercase())
+                    && gslapper_is_supported(&executable)
+                {
+                    available_changers.push(changer);
+                }
+            }
             WallpaperChangers::Swaybg(_)
             | WallpaperChangers::MpvPaper(_)
-            | WallpaperChangers::Awww(_)
-            | WallpaperChangers::GSlapper(_) => {
+            | WallpaperChangers::Awww(_) => {
                 append_changer_if_in_path(&mut available_changers, changer);
             }
         }
@@ -991,5 +1056,64 @@ fn append_changer_if_in_path(
 ) {
     if which(changer.to_string().to_lowercase()).is_ok() {
         available_changers.push(changer);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gslapper_settings_use_protocol_tokens() {
+        assert_eq!(GSllapperScaleMode::Fill.as_arg(), "fill");
+        assert_eq!(GSllapperScaleMode::Panscan.as_arg(), "panscan");
+        assert_eq!(GSllapperPauseMode::AutoPause.as_arg(), Some("-p"));
+        assert_eq!(GSllapperPauseMode::AutoStop.as_arg(), Some("-s"));
+        assert_eq!(GSllapperPauseMode::None.as_arg(), None);
+    }
+
+    #[test]
+    fn gslapper_settings_validate_gslapper_limits() {
+        let mut settings = GSllaperSettings::default();
+        assert!(settings.validate().is_ok());
+        settings.fps_cap = 59;
+        assert!(settings.validate().is_err());
+        settings.fps_cap = 60;
+        settings.transition_duration = 5.1;
+        assert!(settings.validate().is_err());
+    }
+
+    #[test]
+    fn gslapper_image_formats_match_version_1_5() {
+        let formats = WallpaperChangers::GSlapper(GSllaperSettings::default()).accepted_formats();
+        for extension in ["jpg", "jpeg", "png", "webp"] {
+            assert!(formats.contains(&extension.to_owned()));
+        }
+        for extension in ["gif", "bmp", "tif", "tiff"] {
+            assert!(!formats.contains(&extension.to_owned()));
+        }
+    }
+
+    #[test]
+    fn old_gslapper_settings_receive_new_defaults() {
+        let settings: GSllaperSettings = serde_json::from_str(
+            r#"{"scale_mode":"Fill","pause_mode":"None","loop_video":true,"additional_options":""}"#,
+        )
+        .unwrap();
+        assert_eq!(settings.fps_cap, 30);
+        assert_eq!(settings.cache_size_mb, 256);
+        assert_eq!(settings.transition_duration, 0.5);
+    }
+
+    #[test]
+    fn runtime_transition_changes_do_not_require_restart() {
+        let current = GSllaperSettings::default();
+        let mut changed = current.clone();
+        changed.transition_enabled = true;
+        changed.transition_duration = 1.25;
+        assert!(!current.launch_settings_changed(&changed));
+
+        changed.fps_cap = 60;
+        assert!(current.launch_settings_changed(&changed));
     }
 }


### PR DESCRIPTION
## Problem

Waytrogen kills every gSlapper process when a user changes one wallpaper.

The backend sends `quit` to a shared `/tmp/gslapper.sock`, runs `pkill -9 gslapper`, then starts a new process for each selection. On a multi-monitor desktop, changing DP-1 can stop DP-3. It can also kill gSlapper sessions started outside Waytrogen and discard IPC state that gSlapper 1.5 can reuse.

## Changes

- Manage one gSlapper process per output through Waytrogen-owned sockets under `$XDG_RUNTIME_DIR/waytrogen`.
- Reuse ready processes through Unix IPC and limit stops or restarts to overlapping outputs.
- Preserve gSlapper sessions started outside Waytrogen and keep managed wallpapers running after Waytrogen or its launching terminal exits.
- Add a settings dialog for playback, transitions, FPS, cache, and GStreamer options.
- Require gSlapper 1.5 features, return backend errors to the UI, and hide GIF files until their startup path is reliable.

## Testing

- `cargo test --offline`: 25 passed.
- `git diff --check`: passed.
- `rustfmt --edition 2024 --check src/changers/gslapper.rs src/wallpaper_changers.rs`: passed.
- Tested on niri with DP-1 and DP-3: per-output and `All` changes, separate playback, pause and resume, static-image fades, FPS changes, and MP4 playback.
- Confirmed that a greeter-owned gSlapper process remains untouched.
- Confirmed wallpaper persistence after closing Waytrogen, pressing Ctrl+C, and closing its launching terminal.
- Checked released gSlapper 1.5 IPC behavior and current gSlapper source compatibility.

## Screenshots

### Main screen

![Waytrogen main screen with gSlapper selected](https://raw.githubusercontent.com/Nomadcxx/waytrogen/dd98f7e25e6bfda393dda16d5e36a54c5b2d6936/main.png)

### gSlapper settings

![gSlapper settings dialog](https://raw.githubusercontent.com/Nomadcxx/waytrogen/dd98f7e25e6bfda393dda16d5e36a54c5b2d6936/settings.png)
