### PR TITLE
fix: non-UTF-8 wallpaper paths abort the thumbnail pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4886,7 +4886,7 @@ dependencies = [
 
 [[package]]
 name = "waytrogen"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/src/changers/hyprpaper.rs
+++ b/src/changers/hyprpaper.rs
@@ -77,7 +77,7 @@ pub fn change_hyprpaper_wallpaper(
                         .arg("wallpaper")
                         .arg(format!(
                             "{monitor},{},{}",
-                            image.to_str().unwrap(),
+                            image.to_string_lossy(),
                             fit_mode
                         ))
                         .spawn()
@@ -93,7 +93,7 @@ pub fn change_hyprpaper_wallpaper(
                 .arg("wallpaper")
                 .arg(format!(
                     "{monitor},{},{}",
-                    image.to_str().unwrap(),
+                    image.to_string_lossy(),
                     fit_mode
                 ))
                 .spawn()

--- a/src/changers/swaybg.rs
+++ b/src/changers/swaybg.rs
@@ -95,7 +95,7 @@ fn build_command(command: &mut Command, settings: &SwaybgSettings, image: &Path,
 
     command
         .arg("-i")
-        .arg(image.to_str().unwrap())
+        .arg(image.as_os_str())
         .arg("-m")
         .arg(mode)
         .arg("-c")

--- a/src/common.rs
+++ b/src/common.rs
@@ -45,21 +45,23 @@ impl CacheImageFile {
         Self::create_gtk_image(path, &image)
     }
 
-    fn get_metadata(path: &Path) -> anyhow::Result<(String, String, u32)> {
-        let path = path.to_path_buf();
-        let name = path.file_name().unwrap().to_str().unwrap().to_owned();
-        let date = std::fs::File::open(path.clone())?.metadata()?.modified()?;
+    fn get_metadata(path: &Path) -> anyhow::Result<(String, u32)> {
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let date = std::fs::File::open(path)?.metadata()?.modified()?;
         let date = u32::try_from(date.duration_since(UNIX_EPOCH)?.as_secs())?;
-        Ok((path.to_str().unwrap().to_string(), name, date))
+        Ok((name, date))
     }
 
     fn create_gtk_image(path: &Path, image: &Path) -> anyhow::Result<CacheImageFile> {
         let fields = Self::get_metadata(path)?;
         let image_file = CacheImageFile {
             cached_image_path: image.to_path_buf(),
-            path: PathBuf::from(fields.0),
-            name: fields.1,
-            date: fields.2,
+            path: path.to_path_buf(),
+            name: fields.0,
+            date: fields.1,
             favorite: false,
         };
         Ok(image_file)
@@ -75,13 +77,13 @@ impl CacheImageFile {
         Err(anyhow::anyhow!(
             "{}: {}",
             TRANSLATION.get_translation("failed-to-create-thumbnail-for"),
-            path.as_os_str().to_str().unwrap_or_default()
+            path.to_string_lossy()
         ))
     }
     fn try_write_thumbnail_with_ffmpeg(path: &Path) -> anyhow::Result<PathBuf> {
         let temp_dir = String::from_utf8(Command::new("mktemp").arg("-d").output()?.stdout)?;
         let output_path = PathBuf::from(temp_dir.trim()).join("temp.png");
-        trace!("ffmpeg Output Path: {}", output_path.to_str().unwrap());
+        trace!("ffmpeg Output Path: {}", output_path.to_string_lossy());
         let code = Command::new("ffmpeg")
             .arg("-i")
             .arg(path)

--- a/src/database.rs
+++ b/src/database.rs
@@ -13,7 +13,7 @@ impl DatabaseConnection {
     pub fn new() -> anyhow::Result<DatabaseConnection> {
         let xdg_dirs = xdg::BaseDirectories::with_prefix(CONFIG_APP_NAME);
         let cache_path = xdg_dirs.place_cache_file(CACHE_FILE_NAME)?;
-        let conn = Connection::open(cache_path.to_str().unwrap())?;
+        let conn = Connection::open(cache_path.to_string_lossy().as_ref())?;
         let query = "
       CREATE TABLE IF NOT EXISTS imagefile
         (
@@ -33,7 +33,7 @@ impl DatabaseConnection {
         let mut statement = self.connetion.prepare(query)?;
 
         let mut pix_buf_bytes = statement
-            .query_map([path.to_str().unwrap_or_default()], |row| {
+            .query_map([&path.to_string_lossy()], |row| {
                 let favorite = row.get::<usize, i32>(4)?;
                 let favorite = favorite > 0;
                 Ok(CacheImageFile {
@@ -67,10 +67,10 @@ impl DatabaseConnection {
         self.connetion.execute(
             query,
             (
-                &image_file.cached_image_path.to_str().unwrap(),
+                &image_file.cached_image_path.to_string_lossy(),
                 &image_file.name,
                 &image_file.date,
-                &image_file.path.to_str().unwrap_or_default(),
+                &image_file.path.to_string_lossy(),
                 &favorite,
             ),
         )?;
@@ -81,7 +81,11 @@ impl DatabaseConnection {
     pub fn check_cache(path: &Path) -> anyhow::Result<CacheImageFile> {
         let conn = DatabaseConnection::new()?;
         match conn.select_image_file(path) {
-            Ok(f) => {
+            Ok(mut f) => {
+                // The database stores a lossy representation of the path only as a
+                // cache key. Always keep the real filesystem path from the caller so
+                // subsequent file operations (e.g. applying the wallpaper) work.
+                f.path = path.to_path_buf();
                 trace!("{}: {:#?}", TRANSLATION.get_translation("cache-hit"), f);
                 Ok(f)
             }
@@ -89,7 +93,7 @@ impl DatabaseConnection {
                 trace!(
                     "{}: {} {}",
                     TRANSLATION.get_translation("cache-miss"),
-                    path.to_str().unwrap(),
+                    path.to_string_lossy(),
                     e
                 );
                 match CacheImageFile::from_file(path) {
@@ -97,13 +101,13 @@ impl DatabaseConnection {
                         trace!(
                             "{} {}",
                             TRANSLATION.get_translation("picture-created-successfully"),
-                            g.path.to_str().unwrap_or_default()
+                            g.path.to_string_lossy()
                         );
                         conn.insert_image_file(&g)?;
                         debug!(
                             "{} {}",
                             "Picture inserted into database.",
-                            &g.path.to_str().unwrap_or_default()
+                            &g.path.to_string_lossy()
                         );
                         Ok(g)
                     }
@@ -111,7 +115,7 @@ impl DatabaseConnection {
                         warn!(
                             "{}: {} {}",
                             TRANSLATION.get_translation("file-could-not-be-converted-to-a-picture"),
-                            path.to_str().unwrap(),
+                            path.to_string_lossy(),
                             e
                         );
                         Err(e)


### PR DESCRIPTION
## Problem

Waytrogen aborts while thumbnailing a wallpaper folder that contains a non-UTF-8 filename. A directory named `Rosé Pine` where the `é` is Latin-1 `0xE9` is enough. `Path::to_str()` returns `None` for that path, and the thumbnail cache called `to_str().unwrap()` in several places. Those unwraps run inside the rayon `into_par_iter()` loop, so one `None` panics a worker and rayon takes down the whole process:

```
thread panicked at src/database.rs:92:35:
called `Option::unwrap()` on a `None` value
Rayon: detected unexpected panic; aborting
```

It reproduces on `~/Pictures/wallpapers`, which has a `Rosé Pine` subfolder. Valid-UTF-8 folders load fine, so the crash only appears once a non-ASCII, non-UTF-8 name is somewhere in the tree.

## Fix

Replace `to_str().unwrap()` on user image paths with lossy or `OsStr` handling:

- `database.rs`, `common.rs`: `to_string_lossy()` for SQL binding and log lines.
- `swaybg.rs`: pass `image.as_os_str()` to `Command::arg`, so the spawned process receives the original path bytes unchanged.
- `hyprpaper.rs`: `to_string_lossy()` inside the `hyprctl` argument string.

The DB `path` column now holds a lossy string used only as a cache key. `check_cache` overwrites `CacheImageFile.path` with the caller's real `PathBuf` on a cache hit, so applying a wallpaper still runs on the exact bytes from `WalkDir` rather than the lossy round-trip. `get_metadata` stops reconstructing a lossy full path and returns the lossy `name` and `date` only; `create_gtk_image` keeps the caller's original `PathBuf`.

`Cargo.lock` is synced to the `1.0.1` already declared in `Cargo.toml`.

## Verification

- `cargo test`: 25 passed, 0 failed.
- `cargo build --release`: succeeds.
- Cleared the cache with `--delete-cache`, then ran the release build with `--log-level 4` over a folder tree: thumbnails generate and insert, no panic, no rayon abort.

`to_string_lossy()` is the identity transform on valid UTF-8, so existing folders are byte-for-byte unaffected.

## Known limitation

`swaybg` gets the original bytes via `as_os_str()`. `hyprpaper` talks to `hyprctl` over a text command, so a path with no valid UTF-8 form is passed lossily; a genuinely non-UTF-8 filename may not resolve on the hyprpaper backend. The text protocol has no byte-exact form, so this is the ceiling for hyprpaper rather than a regression. The crash is gone in both backends.
