### PR TITLE
perf: open the thumbnail cache in WAL mode with a busy timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4886,7 +4886,7 @@ dependencies = [
 
 [[package]]
 name = "waytrogen"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/src/changers/hyprpaper.rs
+++ b/src/changers/hyprpaper.rs
@@ -77,7 +77,7 @@ pub fn change_hyprpaper_wallpaper(
                         .arg("wallpaper")
                         .arg(format!(
                             "{monitor},{},{}",
-                            image.to_str().unwrap(),
+                            image.to_string_lossy(),
                             fit_mode
                         ))
                         .spawn()
@@ -93,7 +93,7 @@ pub fn change_hyprpaper_wallpaper(
                 .arg("wallpaper")
                 .arg(format!(
                     "{monitor},{},{}",
-                    image.to_str().unwrap(),
+                    image.to_string_lossy(),
                     fit_mode
                 ))
                 .spawn()

--- a/src/changers/swaybg.rs
+++ b/src/changers/swaybg.rs
@@ -95,7 +95,7 @@ fn build_command(command: &mut Command, settings: &SwaybgSettings, image: &Path,
 
     command
         .arg("-i")
-        .arg(image.to_str().unwrap())
+        .arg(image.as_os_str())
         .arg("-m")
         .arg(mode)
         .arg("-c")

--- a/src/common.rs
+++ b/src/common.rs
@@ -45,21 +45,23 @@ impl CacheImageFile {
         Self::create_gtk_image(path, &image)
     }
 
-    fn get_metadata(path: &Path) -> anyhow::Result<(String, String, u32)> {
-        let path = path.to_path_buf();
-        let name = path.file_name().unwrap().to_str().unwrap().to_owned();
-        let date = std::fs::File::open(path.clone())?.metadata()?.modified()?;
+    fn get_metadata(path: &Path) -> anyhow::Result<(String, u32)> {
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let date = std::fs::File::open(path)?.metadata()?.modified()?;
         let date = u32::try_from(date.duration_since(UNIX_EPOCH)?.as_secs())?;
-        Ok((path.to_str().unwrap().to_string(), name, date))
+        Ok((name, date))
     }
 
     fn create_gtk_image(path: &Path, image: &Path) -> anyhow::Result<CacheImageFile> {
         let fields = Self::get_metadata(path)?;
         let image_file = CacheImageFile {
             cached_image_path: image.to_path_buf(),
-            path: PathBuf::from(fields.0),
-            name: fields.1,
-            date: fields.2,
+            path: path.to_path_buf(),
+            name: fields.0,
+            date: fields.1,
             favorite: false,
         };
         Ok(image_file)
@@ -75,13 +77,13 @@ impl CacheImageFile {
         Err(anyhow::anyhow!(
             "{}: {}",
             TRANSLATION.get_translation("failed-to-create-thumbnail-for"),
-            path.as_os_str().to_str().unwrap_or_default()
+            path.to_string_lossy()
         ))
     }
     fn try_write_thumbnail_with_ffmpeg(path: &Path) -> anyhow::Result<PathBuf> {
         let temp_dir = String::from_utf8(Command::new("mktemp").arg("-d").output()?.stdout)?;
         let output_path = PathBuf::from(temp_dir.trim()).join("temp.png");
-        trace!("ffmpeg Output Path: {}", output_path.to_str().unwrap());
+        trace!("ffmpeg Output Path: {}", output_path.to_string_lossy());
         let code = Command::new("ffmpeg")
             .arg("-i")
             .arg(path)

--- a/src/database.rs
+++ b/src/database.rs
@@ -13,7 +13,7 @@ impl DatabaseConnection {
     pub fn new() -> anyhow::Result<DatabaseConnection> {
         let xdg_dirs = xdg::BaseDirectories::with_prefix(CONFIG_APP_NAME);
         let cache_path = xdg_dirs.place_cache_file(CACHE_FILE_NAME)?;
-        let conn = Connection::open(cache_path.to_str().unwrap())?;
+        let conn = Connection::open(cache_path.to_string_lossy().as_ref())?;
         let query = "
       CREATE TABLE IF NOT EXISTS imagefile
         (
@@ -33,7 +33,7 @@ impl DatabaseConnection {
         let mut statement = self.connetion.prepare(query)?;
 
         let mut pix_buf_bytes = statement
-            .query_map([path.to_str().unwrap_or_default()], |row| {
+            .query_map([&path.to_string_lossy()], |row| {
                 let favorite = row.get::<usize, i32>(4)?;
                 let favorite = favorite > 0;
                 Ok(CacheImageFile {
@@ -67,10 +67,10 @@ impl DatabaseConnection {
         self.connetion.execute(
             query,
             (
-                &image_file.cached_image_path.to_str().unwrap(),
+                &image_file.cached_image_path.to_string_lossy(),
                 &image_file.name,
                 &image_file.date,
-                &image_file.path.to_str().unwrap_or_default(),
+                &image_file.path.to_string_lossy(),
                 &favorite,
             ),
         )?;
@@ -81,7 +81,11 @@ impl DatabaseConnection {
     pub fn check_cache(path: &Path) -> anyhow::Result<CacheImageFile> {
         let conn = DatabaseConnection::new()?;
         match conn.select_image_file(path) {
-            Ok(f) => {
+            Ok(mut f) => {
+                // The database stores a lossy representation of the path only as a
+                // cache key. Always keep the real filesystem path from the caller so
+                // subsequent file operations (e.g. applying the wallpaper) work.
+                f.path = path.to_path_buf();
                 trace!("{}: {:#?}", TRANSLATION.get_translation("cache-hit"), f);
                 Ok(f)
             }
@@ -89,7 +93,7 @@ impl DatabaseConnection {
                 trace!(
                     "{}: {} {}",
                     TRANSLATION.get_translation("cache-miss"),
-                    path.to_str().unwrap(),
+                    path.to_string_lossy(),
                     e
                 );
                 match CacheImageFile::from_file(path) {
@@ -97,13 +101,13 @@ impl DatabaseConnection {
                         trace!(
                             "{} {}",
                             TRANSLATION.get_translation("picture-created-successfully"),
-                            g.path.to_str().unwrap_or_default()
+                            g.path.to_string_lossy()
                         );
                         conn.insert_image_file(&g)?;
                         debug!(
                             "{} {}",
                             "Picture inserted into database.",
-                            &g.path.to_str().unwrap_or_default()
+                            &g.path.to_string_lossy()
                         );
                         Ok(g)
                     }
@@ -111,7 +115,7 @@ impl DatabaseConnection {
                         warn!(
                             "{}: {} {}",
                             TRANSLATION.get_translation("file-could-not-be-converted-to-a-picture"),
-                            path.to_str().unwrap(),
+                            path.to_string_lossy(),
                             e
                         );
                         Err(e)

--- a/src/database.rs
+++ b/src/database.rs
@@ -14,17 +14,22 @@ impl DatabaseConnection {
         let xdg_dirs = xdg::BaseDirectories::with_prefix(CONFIG_APP_NAME);
         let cache_path = xdg_dirs.place_cache_file(CACHE_FILE_NAME)?;
         let conn = Connection::open(cache_path.to_string_lossy().as_ref())?;
-        let query = "
-      CREATE TABLE IF NOT EXISTS imagefile
-        (
-           image TEXT NOT NULL,
-           name TEXT NOT NULL,
-           date INTEGER NOT NULL,
-           path TEXT NOT NULL,
-           favorite INTEGER NOT NULL
-        );
-     ";
-        conn.execute(query, ())?;
+        // WAL mode + a busy timeout make concurrent thumbnail cache writes from
+        // the rayon thread pool much less likely to fail with "database is locked".
+        conn.execute_batch(
+            "
+            PRAGMA journal_mode = WAL;
+            PRAGMA busy_timeout = 5000;
+            CREATE TABLE IF NOT EXISTS imagefile
+              (
+                 image TEXT NOT NULL,
+                 name TEXT NOT NULL,
+                 date INTEGER NOT NULL,
+                 path TEXT NOT NULL,
+                 favorite INTEGER NOT NULL
+              );
+            ",
+        )?;
         Ok(DatabaseConnection { connetion: conn })
     }
 


### PR DESCRIPTION
> Stacked on #62. Review and merge that first. Until it lands this PR's diff also includes #62's commit, since the base can only be upstream `main`; the WAL change itself is the single commit `perf: open the thumbnail cache in WAL mode with a busy timeout`. Once #62 merges, this branch rebases onto `main` and the diff drops to that one commit.

## Problem

`DatabaseConnection::new()` runs once per file inside the rayon thumbnail loop, so a large folder opens many connections that all write to the same cache. The default rollback journal serializes writers, and with no busy timeout a connection that finds the database locked fails right away with `database is locked` instead of waiting for the lock to clear.

## Fix

Set two pragmas on each connection at open time:

- `journal_mode = WAL`: readers no longer block the single writer, which suits the read-heavy cache-hit path.
- `busy_timeout = 5000`: a blocked writer retries for up to 5s before returning an error.

The `CREATE TABLE` moves into the same `execute_batch` call so a fresh cache gets the pragmas before its first write.

## Verification

- `cargo test`: 25 passed, 0 failed.
- `cargo build --release`: succeeds.

## Scope

This is preventive. On this branch I have not reproduced a `database is locked` failure in practice, but the per-file connection pattern makes it reachable under a large parallel thumbnailing pass, and WAL plus a busy timeout is the standard fix. A follow-up could share one connection across the loop instead of opening one per file; I kept this change small and left that out.
